### PR TITLE
allow for pushing to PyPI based on tags (a la psc)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,29 @@
+image: docker:stable
+
+services:
+  - docker:dind
+
+stages:
+  - pypi
+
+push-to-pypi:
+  image: python:3.5
+  stage: pypi
+  only:
+    - tags
+  before_script:
+    - pip install --upgrade setuptools wheel twine
+  script:
+    - python setup.py sdist bdist_wheel
+
+    # check git tag version vs setup.py version. bail if not equal.
+    - >-
+      tagver=$(git describe --abbrev=0 --tags)
+      setupver=$(grep "version=" setup.py | cut -d"'" -f 2)
+      if [ $tagver != $setupver ]; then
+        echo "git tag version ($tagver) does not match setup.py version ($setupver)"
+        exit 1
+      fi
+    # using env variables from Gitlab: TWINE_USERNAME, TWINE_PASSWORD, TWINE_REPOSITORY_URL
+    - twine upload dist/*
+    


### PR DESCRIPTION
this won't work until the polyswarm-api PyPI project is transferred ownership to polyswarm