### PR TITLE
Switch to hunt_id for rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ results = api.rescan_file("275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538
 
 results = api.new_live_hunt(open("eicar.yara").read()) 
 
-results = api.get_live_results(rule_id=results['result']['rule_id'])
+results = api.get_live_results(hunt_id=results['result']['huntscan_id'])
 
 results = api.new_historical_hunt(open("eicar.yara").read()) 
 
-results = api.get_historical_results(rule_id=results['result']['rule_id'])
+results = api.get_historical_results(hunt_id=results['result']['huntscan_id'])
 
 results = api.get_stream(destination_dir="/my/malware/path")
 ```

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ results = api.rescan_file("275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538
 
 results = api.new_live_hunt(open("eicar.yara").read()) 
 
-results = api.get_live_results(hunt_id=results['result']['huntscan_id'])
+results = api.get_live_results(hunt_id=results['result']['hunt_id'])
 
 results = api.new_historical_hunt(open("eicar.yara").read()) 
 
-results = api.get_historical_results(hunt_id=results['result']['huntscan_id'])
+results = api.get_historical_results(hunt_id=results['result']['hunt_id'])
 
 results = api.get_stream(destination_dir="/my/malware/path")
 ```

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r") as readme:
 
 setup(
     name='polyswarm-api',
-    version='0.4.2',
+    version='0.5.0',
     description='Client library to simplify interacting with the PolySwarm consumer API',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -577,17 +577,17 @@ class PolyswarmAsyncAPI(object):
         """
         return await self._new_hunt(rules, "historical")
 
-    async def _get_hunt_results(self, rule_id=None, scan_type="live"):
+    async def _get_hunt_results(self, hunt_id=None, scan_type="live"):
         """
 
-        :param rule_id: Rule ID (None if latest rule results are desired)
+        :param hunt_id: Rule ID (None if latest rule results are desired)
         :param scan_type: Type of scan, "live" or "historical"
         :return: Matches to the rules
         """
 
         params = {}
-        if rule_id is not None:
-            params['id'] = rule_id
+        if hunt_id is not None:
+            params['id'] = hunt_id
 
         async with self.get_semaphore:
             logger.debug(f"Reading results with api-key {self.api_key}")
@@ -610,23 +610,23 @@ class PolyswarmAsyncAPI(object):
                     logger.error('Server request failed')
                     return {'status': "error", 'result': []}
 
-    async def get_live_results(self, rule_id=None):
+    async def get_live_results(self, hunt_id=None):
         """
         Get results from a live scan
 
-        :param rule_id: Rule ID (None if latest rule results are desired)
+        :param hunt_id: ID of the hunt (None if latest rule results are desired)
         :return: Matches to the rules
         """
-        return await self._get_hunt_results(rule_id, "live")
+        return await self._get_hunt_results(hunt_id, "live")
 
-    async def get_historical_results(self, rule_id=None):
+    async def get_historical_results(self, hunt_id=None):
         """
         Get results from a historical scan
 
-        :param rule_id: Rule ID (None if latest rule results are desired)
+        :param hunt_id: ID of the hunt (None if latest rule results are desired)
         :return: Matches to the rules
         """
-        return await self._get_hunt_results(rule_id, "historical")
+        return await self._get_hunt_results(hunt_id, "historical")
 
     async def get_stream(self, destination_dir=None):
         async with aiohttp.ClientSession() as session:
@@ -896,23 +896,23 @@ class PolyswarmAPI(object):
         """
         return self.loop.run_until_complete(self.ps_api.new_historical_hunt(rules))
 
-    def get_live_results(self, rule_id=None):
+    def get_live_results(self, hunt_id=None):
         """
         Get results from a live hunt
 
-        :param rule_id: Rule ID (None if latest rule results are desired)
+        :param hunt_id: ID of the hunt (None if latest rule results are desired)
         :return: Matches to the rules
         """
-        return self.loop.run_until_complete(self.ps_api.get_live_results(rule_id))
+        return self.loop.run_until_complete(self.ps_api.get_live_results(hunt_id))
 
-    def get_historical_results(self, rule_id=None):
+    def get_historical_results(self, hunt_id=None):
         """
         Get results from a historical hunt
 
-        :param rule_id: Rule ID (None if latest rule results are desired)
+        :param hunt_id: ID of the hunt (None if latest hunt results are desired)
         :return: Matches to the rules
         """
-        return self.loop.run_until_complete(self.ps_api.get_historical_results(rule_id))
+        return self.loop.run_until_complete(self.ps_api.get_historical_results(hunt_id))
 
     def get_stream(self, destination_dir=None):
         """

--- a/src/polyswarm_api/__main__.py
+++ b/src/polyswarm_api/__main__.py
@@ -325,14 +325,14 @@ def live_install(ctx, rule_file):
     ctx.obj['output'].write((str(rf)))
 
 
-@click.option('-i', '--rule-id', type=int, help="ID of the rule file (defaults to latest)")
+@click.option('-i', '--hunt-id', type=int, help="ID of the rule file (defaults to latest)")
 @click.option("--download-path", "-d", type=click.Path(file_okay=False), help="In addition to fetching the results, download the files that matched.")
 @live.command("results", short_help="get results from live hunt")
 @click.pass_context
-def live_results(ctx, rule_id, download_path):
+def live_results(ctx, hunt_id, download_path):
     api = ctx.obj['api']
 
-    results = api.get_live_results(rule_id)
+    results = api.get_live_results(hunt_id)
 
     rf = PSHuntResultFormatter(results, color=ctx.obj['color'],
                       output_format=ctx.obj['output_format'])
@@ -359,14 +359,14 @@ def historical_start(ctx, rule_file):
     ctx.obj['output'].write((str(rf)))
 
 
-@click.option('-i', '--rule-id', type=int, help="ID of the rule file (defaults to latest)")
+@click.option('-i', '--hunt-id', type=int, help="ID of the rule file (defaults to latest)")
 @click.option("--download-path", "-d", type=click.Path(file_okay=False), help="In addition to fetching the results, download the files that matched.")
 @historical.command("results", short_help="get results from historical hunt")
 @click.pass_context
-def historical_results(ctx, rule_id, download_path):
+def historical_results(ctx, hunt_id, download_path):
     api = ctx.obj['api']
 
-    results = api.get_historical_results(rule_id)
+    results = api.get_historical_results(hunt_id)
 
     rf = PSHuntResultFormatter(results, color=ctx.obj['color'],
                       output_format=ctx.obj['output_format'])

--- a/src/polyswarm_api/_version.py
+++ b/src/polyswarm_api/_version.py
@@ -1,2 +1,2 @@
-__version__ = "0.4.2"
+__version__ = "0.5.0"
 __release_url__ = "https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest"

--- a/src/polyswarm_api/formatting.py
+++ b/src/polyswarm_api/formatting.py
@@ -252,7 +252,7 @@ class PSHuntSubmissionFormatter(PSResultFormatter):
         if self.output_format == "text":
             if self.results['status'] != 'OK':
                 return self._bad("Failed to install rules.\n")
-            return self._good(f"Successfully submitted rules, rule_id: {self.results['result']['rule_id']}\n")
+            return self._good(f"Successfully submitted rules, hunt id: {self.results['result']['huntscan_id']}\n")
 
         elif self.output_format == "json":
             return json.dumps(self.results, indent=4, sort_keys=True)

--- a/src/polyswarm_api/formatting.py
+++ b/src/polyswarm_api/formatting.py
@@ -252,7 +252,7 @@ class PSHuntSubmissionFormatter(PSResultFormatter):
         if self.output_format == "text":
             if self.results['status'] != 'OK':
                 return self._bad("Failed to install rules.\n")
-            return self._good(f"Successfully submitted rules, hunt id: {self.results['result']['huntscan_id']}\n")
+            return self._good(f"Successfully submitted rules, hunt id: {self.results['result']['hunt_id']}\n")
 
         elif self.output_format == "json":
             return json.dumps(self.results, indent=4, sort_keys=True)


### PR DESCRIPTION
Initial refactor for https://github.com/polyswarm/artifact-index/pull/29/files. Would prefer using `hunt_id` instead though @zv if possible.