### PR TITLE
Initial URL scanning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ Report for file 131f95c51cc819465fa1797f6ccacf9d494aaaff46fa3eac73ae63ffbdfd8267
         zillya: Malicious, metadata: Status:Infected EICAR.TestFile
         k7-engine: Malicious, metadata: Trojan ( 000139291 )
 
+$ polyswarm url https://www.XXXXXX.XXXX/admin.php?f=1.gif
+Scan report for GUID 550bcbfe-7d75-4de0-8d23-8b490e7ee58b
+=========================================================
+Report for file admin.php?f=1.gif, hash: c9d2152432e5ed53513c510b5ce94557313af965ba93f7819651542408344dae
+	Trustlook: Malicious, metadata: [{'malware_family': 'Malware', 'scanner': {'environment': {'operating_system': 'Linux', 'architecture': 'x86_64'}}}]
+
 ```
 
 For information regarding the JSON format, please see [API.md](https://github.com/polyswarm/polyswarm-api/blob/master/API.md).

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ results = api.scan_directory("/path/to/directory")
 
 results = api.scan_file("/path/to/eicar")
 
+results = api.scan_url("http://bad.com")
+
 results = api.search_hash("275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f")
 
 results = api.search_hashes(["275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.20.1
 aiofiles==0.4.0
 # recommended for aiohttp
 aiodns==1.2.0
+polyswarm_artifact==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ requests==2.20.1
 aiofiles==0.4.0
 # recommended for aiohttp
 aiodns==1.2.0
-polyswarm_artifact==1.1.1
+polyswarm_artifact>=1.2.0

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -200,14 +200,14 @@ class PolyswarmAsyncAPI(object):
         # TODO check file-size. For now, we need to handle error.
         data = aiohttp.FormData()
         data.add_field('file', artifact_data_obj, filename=artifact_data_name)
+        data.add_field('artifact-type', artifact_type.name)
 
         params = {"force": "true"} if self.force else {}
-        params['artifact-type'] = artifact_type.name
         async with self.post_semaphore:
             logger.debug(f"Posting artifact {artifact_data_name} with api-key {self.api_key}")
             async with aiohttp.ClientSession() as session:
                 try:
-                    async with session.post(self.community_uri+"/"+artifact_type.name, data=data, params=params,
+                    async with session.post(self.community_uri, data=data, params=params,
                                             headers={"Authorization": self.api_key}) as raw_response:
                         try:
                             response = await raw_response.json()

--- a/src/polyswarm_api/__main__.py
+++ b/src/polyswarm_api/__main__.py
@@ -190,6 +190,33 @@ def scan(ctx, path, force, recursive, timeout):
     ctx.obj['output'].write(str(rf))
 
 
+@click.option('-r', '--url-file', help="File of URLs, one per line.", type=click.File('r'))
+@click.option("-f", "--force", is_flag=True, default=False,  help="Force re-scan even if file has already been analyzed.")
+@click.option("-t", "--timeout", type=click.INT, default=-1, help="How long to wait for results (default: forever, -1)")
+@click.argument('url', nargs=-1, type=click.STRING)
+@polyswarm.command("url", short_help="scan url")
+@click.pass_context
+def url_scan(ctx, url, url_file, force, timeout):
+    """
+    Scan files or directories via PolySwarm
+    """
+    api = ctx.obj['api']
+
+    api.timeout = timeout
+
+    api.set_force(force)
+
+    urls = url
+
+    if url_file:
+        urls.extend([u.strip() for u in open(url_file).readlines()])
+
+    results = api.scan_urls(urls)
+
+    rf = PSResultFormatter(results, color=ctx.obj['color'], output_format=ctx.obj['output_format'])
+    ctx.obj['output'].write(str(rf))
+
+
 @click.option('-r', '--hash-file', help="File of hashes, one per line.", type=click.File('r'))
 @click.option("--hash-type", help="Hash type to search [sha256|sha1|md5], default=sha256", default="sha256")
 @click.argument('hash', nargs=-1, callback=validate_hash)

--- a/src/polyswarm_api/formatting.py
+++ b/src/polyswarm_api/formatting.py
@@ -98,7 +98,7 @@ class PSResultFormatter(object):
                 output.append(self._normal("Scan report for GUID %s\n=========================================================" % result['uuid']))
                 # files in info, lets loop
                 for f in result['files']:
-                    output.append(self._open_group("Report for file %s, hash: %s" %
+                    output.append(self._open_group("Report for artifact %s, hash: %s" %
                                                    (f['filename'], f['hash'])))
                     if 'file_info' in f:
                         # this is in response to a /search/ request, so has some additional file metadata


### PR DESCRIPTION
This adds URL scanning support to `polyswarm-api`. A related PR is open at: https://github.com/polyswarm/consumer/pull/229 . This PR would need to be updated to support the endpoint URL changes made there, as it currently targets what is deployed in prod. As is, however, it should provide basic support for scanning URLs.