### PR TITLE
Change query search route

### DIFF
--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -53,7 +53,7 @@ class PolyswarmAsyncAPI(object):
 
         self.consumer_uri = '{uri}/consumer'.format(uri=self.uri)
         self.search_uri = '{uri}/search'.format(uri=self.uri)
-        self.query_uri = "{uri}/query".format(**{'uri': self.uri})
+        self.query_uri = "{uri}/search/query".format(**{'uri': self.uri})
         self.download_uri = '{uri}/download'.format(uri=self.uri)
         self.community_uri = '{consumer_uri}/{community}'.format(consumer_uri=self.consumer_uri, community=community)
         self.hunt_uri = '{uri}/hunt'.format(uri=self.uri)
@@ -438,7 +438,8 @@ class PolyswarmAsyncAPI(object):
                                 raise Exception('Received non-json response from PolySwarm API: {}'.format(response))
 
                 except Exception as e:
-                    logger.error('Server request failed', e)
+                    logger.error('Server request failed')
+                    logger.exception(e)
                     return {'reason': 'unknown_error', "result": [], "search": query, "status": "error"}
 
         response['search'] = query

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -53,7 +53,7 @@ class PolyswarmAsyncAPI(object):
 
         self.consumer_uri = '{uri}/consumer'.format(uri=self.uri)
         self.search_uri = '{uri}/search'.format(uri=self.uri)
-        self.query_uri = "{uri}/search/query".format(**{'uri': self.uri})
+        self.query_uri = '{uri}/search/query'.format(uri=self.uri)
         self.download_uri = '{uri}/download'.format(uri=self.uri)
         self.community_uri = '{consumer_uri}/{community}'.format(consumer_uri=self.consumer_uri, community=community)
         self.hunt_uri = '{uri}/hunt'.format(uri=self.uri)
@@ -418,8 +418,6 @@ class PolyswarmAsyncAPI(object):
         async with self.get_semaphore:
             async with aiohttp.ClientSession() as session:
 
-                print('{query_uri}/{query}'.format(**{'query_uri': self.query_uri,
-                                                                           'query': parse.quote(json.dumps(query))}))
                 try:
                     async with session.get('{query_uri}/{query}'.format(**{'query_uri': self.query_uri,
                                                                            'query': parse.quote(json.dumps(query))}),

--- a/test/client/client_search_query__test.py
+++ b/test/client/client_search_query__test.py
@@ -28,10 +28,10 @@ class SearchQueryTestCase(PolyApiBaseTestCase):
 
         app = web.Application()
         query = parse.quote(json.dumps(self.test_query))
-        app.router.add_get('/v1/query/{}'.format(query), success_response)
-        app.router.add_get('/v2/query/{}'.format(query), not_found_response)
-        app.router.add_get('/v3/query/{}'.format(query), invalid_query_response)
-        app.router.add_get('/v4/query/{}'.format(query), non_json_response)
+        app.router.add_get('/v1/search/query/{}'.format(query), success_response)
+        app.router.add_get('/v2/search/query/{}'.format(query), not_found_response)
+        app.router.add_get('/v3/search/query/{}'.format(query), invalid_query_response)
+        app.router.add_get('/v4/search/query/{}'.format(query), non_json_response)
         return app
 
     def test_search_query(self):
@@ -48,14 +48,15 @@ class SearchQueryTestCase(PolyApiBaseTestCase):
         results = test_client.search_query(self.test_query)
         self.assertDictEqual(results, expected_results)
 
+
     def test_search_query_invalid_query_from_server(self):
         test_uri = 'http://localhost:{}/v3'.format(self.server.port)
         test_client = PolyswarmAPI(self.test_api_key, uri=test_uri)
 
         with patch('polyswarm_api.logger.error') as mock_logger_error:
             test_client.search_query(self.test_query)
-        self.assertEqual(mock_logger_error.call_args[0][0], 'Server request failed')
-        self.assertEqual(str(mock_logger_error.call_args[0][1]),
+
+        self.assertEqual(str(mock_logger_error.call_args[0][0]),
                          'Error reading from PolySwarm API: Search query is not valid')
 
     def test_search_query_non_json_response_from_server(self):
@@ -64,7 +65,8 @@ class SearchQueryTestCase(PolyApiBaseTestCase):
         expected_results = self._get_test_json_resource('expected_search_query_non_json_results.json')
         with patch('polyswarm_api.logger.error') as mock_logger_error:
             results = test_client.search_query(self.test_query)
-        self.assertEqual(mock_logger_error.call_args[0][0], 'Server request failed')
-        self.assertEqual(str(mock_logger_error.call_args[0][1]),
+
+        print(mock_logger_error.call_args[0][0])
+
+        self.assertEqual(str(mock_logger_error.call_args[0][0]),
                          'Received non-json response from PolySwarm API: Definitely NOT JSON')
-        self.assertDictEqual(results, expected_results)


### PR DESCRIPTION
Changed the route to /search/query, so it uses the same base route /search for queries and hashes.