### PR TITLE
rescan should be a POST request

### DIFF
--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -464,7 +464,7 @@ class PolyswarmAsyncAPI(object):
         async with self.get_semaphore:
             async with aiohttp.ClientSession() as session:
                 try:
-                    async with session.get(
+                    async with session.post(
                             '{community_uri}/rescan/{hash_type}/{hash}'.format(community_uri=self.community_uri,
                                                                                hash_type=hash_type,
                                                                                hash=to_rescan),


### PR DESCRIPTION
Since `rescan` has side-effects, it should be a post. Changed this in `ai` as well.