### PR TITLE
Fixing response for search queries that returned 404

### DIFF
--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -440,9 +440,7 @@ class PolyswarmAsyncAPI(object):
                             response = response.decode('utf-8')
                             raise Exception('Received non-json response from PolySwarm API: {}'.format(response))
 
-                        if raw_response.status == 404:
-                            return {'search': query, 'result': [], 'status': 'OK'}
-                        elif raw_response.status // 100 != 2:
+                        if raw_response.status // 100 != 2:
                             raise Exception('Error reading from PolySwarm API: {}'.format(response['errors']))
 
                 except Exception as e:

--- a/test/client/client_search_query__test.py
+++ b/test/client/client_search_query__test.py
@@ -18,7 +18,8 @@ class SearchQueryTestCase(PolyApiBaseTestCase):
 
         async def not_found_response(request):
             del request
-            return web.Response(text='{}', content_type='application/json', status=404)
+            response = self._get_test_text_resource('search_query_server_success_empty_response.json')
+            return web.Response(text=response, content_type='application/json')
 
         async def invalid_query_response(request):
             del request

--- a/test/client/client_search_query__test.py
+++ b/test/client/client_search_query__test.py
@@ -2,8 +2,6 @@ from aiohttp import web
 from polyswarm_api import PolyswarmAPI
 from test.utils import PolyApiBaseTestCase
 from unittest.mock import patch
-from urllib import parse
-import json
 
 
 class SearchQueryTestCase(PolyApiBaseTestCase):

--- a/test/resources/search_query_server_success_empty_response.json
+++ b/test/resources/search_query_server_success_empty_response.json
@@ -1,0 +1,4 @@
+{
+    "result": [],
+    "status": "OK"
+}


### PR DESCRIPTION
Search queries now return an empty list when no results are found.