### PR TITLE
working hunting pagination

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('README.md', 'r') as readme:
 
 setup(
     name='polyswarm-api',
-    version='0.5.4',
+    version='0.5.5',
     description='Client library to simplify interacting with the PolySwarm consumer API',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -767,7 +767,7 @@ class PolyswarmAsyncAPI(object):
             params['id'] = hunt_id
 
         if with_bounties:
-            params['with_bounties'] = 'true'
+            params['with_bounty_results'] = 'true'
 
         if with_metadata:
             params['with_metadata'] = 'true'

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -711,8 +711,8 @@ class PolyswarmAsyncAPI(object):
             offset = 0
 
         params = {
-            "limit": limit,
-            "offset": offset,
+            'limit': limit,
+            'offset': offset,
         }
 
         if hunt_id is not None:

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -17,7 +17,7 @@ from ._version import __version__, __release_url__
 
 logger = logging.getLogger(__name__)
 
-MAX_HUNT_RESULTS = 5000
+MAX_HUNT_RESULTS = 20000
 
 class PolyswarmAsyncAPI(object):
     """

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -25,7 +25,7 @@ class PolyswarmAsyncAPI(object):
     """
 
     def __init__(self, key, uri='https://api.polyswarm.network/v1', get_limit=10,
-                 post_limit=1, timeout=600, force=False, community='lima', check_version=True):
+                 post_limit=3, timeout=600, force=False, community='lima', check_version=True):
         """
 
         :param key: PolySwarm API key
@@ -691,7 +691,7 @@ class PolyswarmAsyncAPI(object):
         return await self._new_hunt(rules, 'historical')
 
     async def _get_hunt_results(self, hunt_id=None, scan_type='live', limit=MAX_HUNT_RESULTS, offset=0,
-                                all_results=False):
+                                all_results=False, with_metadata=False, with_bounties=False):
         """
 
         :param hunt_id: Rule ID (None if latest rule results are desired)
@@ -699,6 +699,8 @@ class PolyswarmAsyncAPI(object):
         :param limit: Limit the number of scan results, returns the most recent hits
         :param offset: Offset into the result set to return
         :param all_results: Boolean on whether to fetch all results. Note: this ignores limit/offset and can take awhile.
+        :param with_metadata: Whether to include metadata in the results
+        :param with_bounties: Whether to include bounty results in the results
         :return: Matches to the rules
         """
 
@@ -717,6 +719,12 @@ class PolyswarmAsyncAPI(object):
 
         if hunt_id is not None:
             params['id'] = hunt_id
+
+        if with_bounties:
+            params['with_bounties'] = 'true'
+
+        if with_metadata:
+            params['with_metadata'] = 'true'
 
         async with self.get_semaphore:
             logger.debug('Reading results with api-key %s', self.api_key)
@@ -757,7 +765,7 @@ class PolyswarmAsyncAPI(object):
                     return {'status': 'error', 'result': []}
 
     async def get_live_results(self, hunt_id=None, limit=MAX_HUNT_RESULTS, offset=0,
-                                all_results=False):
+                                all_results=False, with_metadata=False, with_bounties=False):
         """
         Get results from a live scan
 
@@ -765,12 +773,14 @@ class PolyswarmAsyncAPI(object):
         :param limit: Limit the number of scan results, returns the most recent hits
         :param offset: Offset into the result set to return
         :param all_results: Boolean on whether to fetch all results. Note: this ignores limit/offset and can take awhile.
+        :param with_metadata: Whether to include metadata in the results
+        :param with_bounties: Whether to include bounty results in the results
         :return: Matches to the rules
         """
-        return await self._get_hunt_results(hunt_id, 'live', limit, offset, all_results)
+        return await self._get_hunt_results(hunt_id, 'live', limit, offset, all_results, with_metadata, with_bounties)
 
     async def get_historical_results(self, hunt_id=None, limit=MAX_HUNT_RESULTS, offset=0,
-                                all_results=False):
+                                all_results=False, with_metadata=False, with_bounties=False):
         """
         Get results from a historical scan
 
@@ -778,9 +788,12 @@ class PolyswarmAsyncAPI(object):
         :param limit: Limit the number of scan results, returns the most recent hits
         :param offset: Offset into the result set to return
         :param all_results: Boolean on whether to fetch all results. Note: this ignores limit/offset and can take awhile.
+        :param with_metadata: Whether to include metadata in the results
+        :param with_bounties: Whether to include bounty results in the results
         :return: Matches to the rules
         """
-        return await self._get_hunt_results(hunt_id, 'historical', limit, offset, all_results)
+        return await self._get_hunt_results(hunt_id, 'historical', limit, offset, all_results,
+                                            with_metadata, with_bounties)
 
     async def get_stream(self, destination_dir=None, since=1440):
         """
@@ -846,7 +859,7 @@ class PolyswarmAPI(object):
     """A synchronous interface to the public and private PolySwarm APIs."""
 
     def __init__(self, key, uri='https://api.polyswarm.network/v1', get_limit=10,
-                 post_limit=1, timeout=600, force=False, community='lima', check_version=True):
+                 post_limit=3, timeout=600, force=False, community='lima', check_version=True):
         """
 
         :param key: PolySwarm API key
@@ -1098,7 +1111,7 @@ class PolyswarmAPI(object):
         return self.loop.run_until_complete(self.ps_api.new_historical_hunt(rules))
 
     def get_live_results(self, hunt_id=None, limit=MAX_HUNT_RESULTS, offset=0,
-                                all_results=False):
+                                all_results=False, with_metadata=False, with_bounties=False):
         """
         Get results from a live hunt
 
@@ -1106,12 +1119,15 @@ class PolyswarmAPI(object):
         :param limit: Limit the number of scan results, returns the most recent hits
         :param offset: Offset into the result set to return
         :param all_results: Boolean on whether to fetch all results. Note: this ignores limit/offset and can take awhile.
+        :param with_metadata: Whether to include metadata in the results
+        :param with_bounties: Whether to include bounty results in the results
         :return: Matches to the rules
         """
-        return self.loop.run_until_complete(self.ps_api.get_live_results(hunt_id, limit, offset, all_results))
+        return self.loop.run_until_complete(self.ps_api.get_live_results(hunt_id, limit, offset, all_results,
+                                                                         with_metadata, with_bounties))
 
     def get_historical_results(self, hunt_id=None, limit=MAX_HUNT_RESULTS, offset=0,
-                                all_results=False):
+                                all_results=False, with_metadata=False, with_bounties=False):
         """
         Get results from a historical hunt
 
@@ -1119,9 +1135,12 @@ class PolyswarmAPI(object):
         :param limit: Limit the number of scan results, returns the most recent hits
         :param offset: Offset into the result set to return
         :param all_results: Boolean on whether to fetch all results. Note: this ignores limit/offset and can take awhile.
+        :param with_metadata: Whether to include metadata in the results
+        :param with_bounties: Whether to include bounty results in the results
         :return: Matches to the rules
         """
-        return self.loop.run_until_complete(self.ps_api.get_historical_results(hunt_id, limit, offset, all_results))
+        return self.loop.run_until_complete(self.ps_api.get_historical_results(hunt_id, limit, offset, all_results,
+                                                                               with_metadata, with_bounties))
 
     def get_stream(self, destination_dir=None, since=1440):
         """

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -17,6 +17,7 @@ from ._version import __version__, __release_url__
 
 logger = logging.getLogger(__name__)
 
+MAX_HUNT_RESULTS = 5000
 
 class PolyswarmAsyncAPI(object):
     """
@@ -689,15 +690,31 @@ class PolyswarmAsyncAPI(object):
         """
         return await self._new_hunt(rules, 'historical')
 
-    async def _get_hunt_results(self, hunt_id=None, scan_type='live'):
+    async def _get_hunt_results(self, hunt_id=None, scan_type='live', limit=MAX_HUNT_RESULTS, offset=0,
+                                all_results=False):
         """
 
         :param hunt_id: Rule ID (None if latest rule results are desired)
         :param scan_type: Type of scan, "live" or "historical"
+        :param limit: Limit the number of scan results, returns the most recent hits
+        :param offset: Offset into the result set to return
+        :param all_results: Boolean on whether to fetch all results. Note: this ignores limit/offset and can take awhile.
         :return: Matches to the rules
         """
 
-        params = {}
+        if limit > MAX_HUNT_RESULTS:
+            limit = MAX_HUNT_RESULTS
+
+        # ignore offset/limit results in case we want all results
+        if all_results:
+            limit = MAX_HUNT_RESULTS
+            offset = 0
+
+        params = {
+            "limit": limit,
+            "offset": offset,
+        }
+
         if hunt_id is not None:
             params['id'] = hunt_id
 
@@ -705,42 +722,65 @@ class PolyswarmAsyncAPI(object):
             logger.debug('Reading results with api-key %s', self.api_key)
             async with aiohttp.ClientSession() as session:
                 try:
-                    async with session.get('{hunt_uri}/{scan_type}/results'.format(hunt_uri=self.hunt_uri,
+                    async def _make_request(hunt_uri, params):
+                        async with session.get('{hunt_uri}/{scan_type}/results'.format(hunt_uri=hunt_uri,
                                                                                    scan_type=scan_type),
                                            params=params,
                                            headers={'Authorization': self.api_key}) as raw_response:
-                        try:
-                            response = await raw_response.json()
-                        except Exception:
-                            response = await raw_response.read() if raw_response else 'None'
-                            logger.error('Received non-json response from PolySwarm API: %s', response)
-                            response = {'status': 'error', 'result': []}
-                        if raw_response.status // 100 != 2:
-                            errors = response.get('errors')
-                            logger.error('Error reading from PolySwarm API: %s', errors)
-                            response = {'status': 'error', 'result': []}
-                        return response
-                except Exception:
+
+
+                            try:
+                                response = await raw_response.json()
+                            except Exception:
+                                response = await raw_response.read() if raw_response else 'None'
+                                logger.error('Received non-json response from PolySwarm API: %s', response)
+                                response = {'status': 'error', 'result': []}
+                            if raw_response.status // 100 != 2:
+                                errors = response.get('errors')
+                                logger.error('Error reading from PolySwarm API: %s', errors)
+                                response = {'status': 'error', 'result': []}
+                            return response
+
+                    agg_response = await _make_request(self.hunt_uri, params)
+
+                    if all_results and not agg_response['status'] == 'error':
+                        total_results = int(agg_response['result']['total'])
+                        for offset in range(limit, total_results, limit):
+                            params['offset'] = offset
+                            response = await _make_request(self.hunt_uri, params)
+                            agg_response['result']['results'].extend(response['result']['results'])
+
+                    return agg_response
+                except Exception as e:
+                    print(e)
                     logger.error('Server request failed')
                     return {'status': 'error', 'result': []}
 
-    async def get_live_results(self, hunt_id=None):
+    async def get_live_results(self, hunt_id=None, limit=MAX_HUNT_RESULTS, offset=0,
+                                all_results=False):
         """
         Get results from a live scan
 
         :param hunt_id: ID of the hunt (None if latest rule results are desired)
+        :param limit: Limit the number of scan results, returns the most recent hits
+        :param offset: Offset into the result set to return
+        :param all_results: Boolean on whether to fetch all results. Note: this ignores limit/offset and can take awhile.
         :return: Matches to the rules
         """
-        return await self._get_hunt_results(hunt_id, 'live')
+        return await self._get_hunt_results(hunt_id, 'live', limit, offset, all_results)
 
-    async def get_historical_results(self, hunt_id=None):
+    async def get_historical_results(self, hunt_id=None, limit=MAX_HUNT_RESULTS, offset=0,
+                                all_results=False):
         """
         Get results from a historical scan
 
         :param hunt_id: ID of the hunt (None if latest rule results are desired)
+        :param limit: Limit the number of scan results, returns the most recent hits
+        :param offset: Offset into the result set to return
+        :param all_results: Boolean on whether to fetch all results. Note: this ignores limit/offset and can take awhile.
         :return: Matches to the rules
         """
-        return await self._get_hunt_results(hunt_id, 'historical')
+        return await self._get_hunt_results(hunt_id, 'historical', limit, offset, all_results)
 
     async def get_stream(self, destination_dir=None, since=1440):
         """
@@ -1057,23 +1097,31 @@ class PolyswarmAPI(object):
         """
         return self.loop.run_until_complete(self.ps_api.new_historical_hunt(rules))
 
-    def get_live_results(self, hunt_id=None):
+    def get_live_results(self, hunt_id=None, limit=MAX_HUNT_RESULTS, offset=0,
+                                all_results=False):
         """
         Get results from a live hunt
 
         :param hunt_id: ID of the hunt (None if latest rule results are desired)
+        :param limit: Limit the number of scan results, returns the most recent hits
+        :param offset: Offset into the result set to return
+        :param all_results: Boolean on whether to fetch all results. Note: this ignores limit/offset and can take awhile.
         :return: Matches to the rules
         """
-        return self.loop.run_until_complete(self.ps_api.get_live_results(hunt_id))
+        return self.loop.run_until_complete(self.ps_api.get_live_results(hunt_id, limit, offset, all_results))
 
-    def get_historical_results(self, hunt_id=None):
+    def get_historical_results(self, hunt_id=None, limit=MAX_HUNT_RESULTS, offset=0,
+                                all_results=False):
         """
         Get results from a historical hunt
 
         :param hunt_id: ID of the hunt (None if latest hunt results are desired)
+        :param limit: Limit the number of scan results, returns the most recent hits
+        :param offset: Offset into the result set to return
+        :param all_results: Boolean on whether to fetch all results. Note: this ignores limit/offset and can take awhile.
         :return: Matches to the rules
         """
-        return self.loop.run_until_complete(self.ps_api.get_historical_results(hunt_id))
+        return self.loop.run_until_complete(self.ps_api.get_historical_results(hunt_id, limit, offset, all_results))
 
     def get_stream(self, destination_dir=None, since=1440):
         """

--- a/src/polyswarm_api/__main__.py
+++ b/src/polyswarm_api/__main__.py
@@ -9,7 +9,7 @@ import json
 
 from aiohttp import ServerDisconnectedError
 
-from . import PolyswarmAPI
+from . import PolyswarmAPI, MAX_HUNT_RESULTS
 from .formatting import PSResultFormatter, PSDownloadResultFormatter, PSSearchResultFormatter, PSHuntResultFormatter, \
     PSHuntSubmissionFormatter, PSStreamFormatter
 
@@ -415,11 +415,15 @@ def live_install(ctx, rule_file):
 @click.option('--download-path', '-d', type=click.Path(file_okay=False),
               help='In addition to fetching the results, download the files that matched.')
 @live.command('results', short_help='get results from live hunt')
+@click.option('-a', '--all', is_flag=True, default=False,
+              help='Request all historical results (could take awhile).')
+@click.option('-l', '--limit', type=int, help='Number of results to request (maximum 10,000)', default=MAX_HUNT_RESULTS)
+@click.option('-o', '--offset', type=int, help='Offset into results to start request from .', default=0)
 @click.pass_context
-def live_results(ctx, hunt_id, download_path):
+def live_results(ctx, hunt_id, download_path, all, limit, offset):
     api = ctx.obj['api']
 
-    results = api.get_live_results(hunt_id)
+    results = api.get_live_results(hunt_id, limit, offset, all)
 
     rf = PSHuntResultFormatter(results, color=ctx.obj['color'],
                                output_format=ctx.obj['output_format'])
@@ -449,12 +453,16 @@ def historical_start(ctx, rule_file):
 @click.option('-i', '--hunt-id', type=int, help='ID of the rule file (defaults to latest)')
 @click.option('--download-path', '-d', type=click.Path(file_okay=False),
               help='In addition to fetching the results, download the files that matched.')
+@click.option('-a', '--all', is_flag=True, default=False,
+              help='Request all historical results (could take awhile).')
+@click.option('-l', '--limit', type=int, help='Number of results to request (maximum 10,000)', default=MAX_HUNT_RESULTS)
+@click.option('-o', '--offset', type=int, help='Offset into results to start request from .', default=0)
 @historical.command('results', short_help='get results from historical hunt')
 @click.pass_context
-def historical_results(ctx, hunt_id, download_path):
+def historical_results(ctx, hunt_id, download_path, all, limit, offset):
     api = ctx.obj['api']
 
-    results = api.get_historical_results(hunt_id)
+    results = api.get_historical_results(hunt_id, limit, offset, all)
 
     rf = PSHuntResultFormatter(results, color=ctx.obj['color'],
                                output_format=ctx.obj['output_format'])

--- a/src/polyswarm_api/__main__.py
+++ b/src/polyswarm_api/__main__.py
@@ -417,7 +417,7 @@ def live_install(ctx, rule_file):
 @live.command('results', short_help='get results from live hunt')
 @click.option('-a', '--all', is_flag=True, default=False,
               help='Request all historical results (could take awhile).')
-@click.option('-l', '--limit', type=int, help='Number of results to request (maximum 10,000)', default=MAX_HUNT_RESULTS)
+@click.option('-l', '--limit', type=int, help='Number of results to request (maximum 20000, default 5000)', default=5000)
 @click.option('-o', '--offset', type=int, help='Offset into results to start request from .', default=0)
 @click.pass_context
 def live_results(ctx, hunt_id, download_path, all, limit, offset):
@@ -455,7 +455,7 @@ def historical_start(ctx, rule_file):
               help='In addition to fetching the results, download the files that matched.')
 @click.option('-a', '--all', is_flag=True, default=False,
               help='Request all historical results (could take awhile).')
-@click.option('-l', '--limit', type=int, help='Number of results to request (maximum 10,000)', default=MAX_HUNT_RESULTS)
+@click.option('-l', '--limit', type=int, help='Number of results to request (maximum 20000, default 5000)', default=5000)
 @click.option('-o', '--offset', type=int, help='Offset into results to start request from .', default=0)
 @historical.command('results', short_help='get results from historical hunt')
 @click.pass_context

--- a/src/polyswarm_api/__main__.py
+++ b/src/polyswarm_api/__main__.py
@@ -419,11 +419,15 @@ def live_install(ctx, rule_file):
               help='Request all historical results (could take awhile).')
 @click.option('-l', '--limit', type=int, help='Number of results to request (maximum 20000, default 5000)', default=5000)
 @click.option('-o', '--offset', type=int, help='Offset into results to start request from .', default=0)
+@click.option('-m', '--with-metadata', is_flag=True, default=False,
+              help='Request metadata associated with artifacts as well.')
+@click.option('-b', '--with-bounties', is_flag=True, default=False,
+              help='Request bounty results associated with artifacts as well')
 @click.pass_context
-def live_results(ctx, hunt_id, download_path, all, limit, offset):
+def live_results(ctx, hunt_id, download_path, all, limit, offset, with_metadata, with_bounties):
     api = ctx.obj['api']
 
-    results = api.get_live_results(hunt_id, limit, offset, all)
+    results = api.get_live_results(hunt_id, limit, offset, all, with_metadata, with_bounties)
 
     rf = PSHuntResultFormatter(results, color=ctx.obj['color'],
                                output_format=ctx.obj['output_format'])
@@ -457,12 +461,16 @@ def historical_start(ctx, rule_file):
               help='Request all historical results (could take awhile).')
 @click.option('-l', '--limit', type=int, help='Number of results to request (maximum 20000, default 5000)', default=5000)
 @click.option('-o', '--offset', type=int, help='Offset into results to start request from .', default=0)
+@click.option('-m', '--with-metadata', is_flag=True, default=False,
+              help='Request metadata associated with artifacts as well.')
+@click.option('-b', '--with-bounties', is_flag=True, default=False,
+              help='Request bounty results associated with artifacts as well')
 @historical.command('results', short_help='get results from historical hunt')
 @click.pass_context
-def historical_results(ctx, hunt_id, download_path, all, limit, offset):
+def historical_results(ctx, hunt_id, download_path, all, limit, offset, with_metadata, with_bounties):
     api = ctx.obj['api']
 
-    results = api.get_historical_results(hunt_id, limit, offset, all)
+    results = api.get_historical_results(hunt_id, limit, offset, all, with_metadata, with_bounties)
 
     rf = PSHuntResultFormatter(results, color=ctx.obj['color'],
                                output_format=ctx.obj['output_format'])

--- a/src/polyswarm_api/_version.py
+++ b/src/polyswarm_api/_version.py
@@ -1,2 +1,2 @@
-__version__ = '0.5.4'
+__version__ = '0.5.5'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'

--- a/src/polyswarm_api/formatting.py
+++ b/src/polyswarm_api/formatting.py
@@ -246,14 +246,15 @@ class PSHuntResultFormatter(PSResultFormatter):
                 output.append(self._info('First seen: {first_seen}'.format(first_seen=artifact.first_seen)))
 
                 # gather instance data
-                countries, filenames = set(), set()
-                for artifact_instance in artifact.artifact_instances:
-                    if artifact_instance.country:
-                        countries.add(artifact_instance.country)
-                    if artifact_instance.name:
-                        filenames.add(artifact_instance.name)
-                output.append(self._info('Observed countries: {countries}'.format(countries=','.join(countries))))
-                output.append(self._info('Observed filenames: {filenames}'.format(filenames=','.join(filenames))))
+                if hasattr(artifact, 'artifact_instances'):
+                    countries, filenames = set(), set()
+                    for artifact_instance in artifact.artifact_instances:
+                        if artifact_instance.country:
+                            countries.add(artifact_instance.country)
+                        if artifact_instance.name:
+                            filenames.add(artifact_instance.name)
+                    output.append(self._info('Observed countries: {countries}'.format(countries=','.join(countries))))
+                    output.append(self._info('Observed filenames: {filenames}'.format(filenames=','.join(filenames))))
                 output.append(self._close_group())
             return '\n'.join(output)
         elif self.output_format == 'json':

--- a/src/polyswarm_api/formatting.py
+++ b/src/polyswarm_api/formatting.py
@@ -227,7 +227,8 @@ class PSHuntResultFormatter(PSResultFormatter):
                 output.append(self._bad('(Did not find any results yet for this hunt.)\n'))
                 return '\n'.join(output)
 
-            output.append(self._good('Found {count} samples in this hunt.'.format(count=len(results))))
+            output.append(self._good('Found {total} samples in this hunt, displaying {count}.'.format(
+                count=len(results), total=self.hunt_results.result.total)))
 
             for result in results:
                 output.append(self._good('Match on rule {name}'.format(name=result.rule_name) +


### PR DESCRIPTION
This PR adds support for both pagination in `polyswarm-api` and no longer requests metadata or bounty results by default. These can still be requested with `--with-metadata/-m` and `--with-bounties/-b` options.