### PR TITLE
Multi-artifact submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ api = polyswarm_api.PolyswarmAPI(key=api_key)
 ```python
 results = api.scan_directory("/path/to/directory")
 
-results = api.scan_file("/path/to/eicar")
+results = api.scan_files(["/path/to/eicar"])
 
-results = api.scan_url("http://bad.com")
+results = api.scan_urls(["http://bad.com"])
 ```
 
 #### Perform Searches

--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ api = polyswarm_api.PolyswarmAPI(key=api_key)
 ```python
 results = api.scan_directory("/path/to/directory")
 
-results = api.scan_files(["/path/to/eicar"])
+results = api.scan_file("/path/to/eicar")
 
-results = api.scan_urls(["http://bad.com"])
+results = api.scan_url("http://bad.com")
 ```
 
 #### Perform Searches

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -954,7 +954,6 @@ class PolyswarmAPI(object):
         Scan a single file-like object using the PS API asynchronously.
 
         :param to_scan: File-like object to scan.
-        decorator to be used for rate limiting ind
         :param filename: Filename to use
         :return: JSON report
         """

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -400,7 +400,7 @@ class PolyswarmAsyncAPI(object):
 
     async def scan_url(self, to_scan, name='url'):
         """
-        Scan a single URL using the PS API synchronously
+        Scan a single URL using the PS API asynchronously
 
         :param to_scan: URL to scan
         :param name: name to associate with the artifact
@@ -410,7 +410,7 @@ class PolyswarmAsyncAPI(object):
 
     async def scan_file(self, to_scan):
         """
-        Scan a single file using the PS API synchronously.
+        Scan a single file using the PS API asynchronously.
 
         :param to_scan: Path of file to scan.
         :return: JSON report file
@@ -419,7 +419,7 @@ class PolyswarmAsyncAPI(object):
 
     async def post_url(self, url):
         """
-        POST URL to the PS API to be scanned synchronously
+        POST URL to the PS API to be scanned asynchronously
 
         :param url: URL to scan
         :return: Dictionary of the result code and the UUID of the scan (if successful)
@@ -428,7 +428,7 @@ class PolyswarmAsyncAPI(object):
 
     async def post_file(self, file_obj, filename):
         """
-        POST file to the PS API to be scanned synchronously.
+        POST file to the PS API to be scanned asynchronously.
 
         :param file_obj: File-like object to POST to the API
         :param filename: Name of file to be given to the API

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -945,25 +945,14 @@ class PolyswarmAPI(object):
         """
         return self.loop.run_until_complete(self.ps_api.get_file_data(sha256))
 
-    def scan_fileobj(self, to_scan, filename='data'):
+    def scan_fileobjs(self, to_scan):
         """
-        Scan a single file-like object using the PS API asynchronously.
+        Scan a collection of file-like object using the PS API asynchronously.
 
-        :param to_scan: File-like object to scan.
-        :param filename: Filename to use
+        :param to_scan: A list of (file-like object, filename) tuples to scan.
         :return: JSON report
         """
-        return self.loop.run_until_complete(self.ps_api.scan_fileobj(to_scan, filename))
-
-    def scan_file(self, to_scan):
-        """
-        Scan a single file using the PS API synchronously.
-
-        :param to_scan: Path of file to scan.
-        :return: JSON report file
-        """
-
-        return self.loop.run_until_complete(self.ps_api.scan_file(to_scan))
+        return self.loop.run_until_complete(self.ps_api.scan_fileobjs(to_scan))
 
     def scan_files(self, files):
         """
@@ -973,16 +962,6 @@ class PolyswarmAPI(object):
         :return: JSON report file
         """
         return self.loop.run_until_complete(self.ps_api.scan_files(files))
-
-    def scan_url(self, to_scan, name='url'):
-        """
-        Scan a single URL using the PS API synchronously
-
-        :param to_scan: URL to scan
-        :param name: name to associate with the artifact
-        :return: JSON report
-        """
-        return self.loop.run_until_complete(self.ps_api.scan_url(to_scan, name))
 
     def scan_urls(self, to_scan):
         """
@@ -1052,25 +1031,6 @@ class PolyswarmAPI(object):
         :return: JSON report file
         """
         return self.loop.run_until_complete(self.ps_api.lookup_uuids(uuids))
-
-    def post_file(self, file_obj, filename):
-        """
-        POST file to the PS API to be scanned synchronously.
-
-        :param file_obj: File-like object to POST to the API
-        :param filename: Name of file to be given to the API
-        :return: Dictionary of the result code and the UUID of the upload (if successful)
-        """
-        return self.loop.run_until_complete(self.ps_api.post_file(file_obj, filename))
-
-    def post_url(self, url):
-        """
-        POST URL to the PS API to be scanned synchronously
-
-        :param url: URL to scan
-        :return: Dictionary of the result code and the UUID of the scan (if successful)
-        """
-        return self.loop.run_until_complete(self.ps_api.post_url(url))
 
     def download_file(self, h, destination_dir, with_metadata=False, hash_type='sha256'):
         """

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -253,7 +253,7 @@ class PolyswarmAsyncAPI(object):
                         logger.error('Server request failed')
                         raise exceptions.RequestFailedException(failure_message)
         except exceptions.PolyswarmAPIException as e:
-            return {'filename': str(e), 'files': []}
+            return {'filename': str(e), 'files': [], 'status': 'error', 'result': 'error'}
 
     async def lookup_uuid(self, uuid):
         """
@@ -355,7 +355,7 @@ class PolyswarmAsyncAPI(object):
                     return result
             return await self.wait_for_results(results)
         except exceptions.PolyswarmAPIException as e:
-            return {'filename': str(e), 'files': []}
+            return {'filename': str(e), 'files': [], 'status': 'error', 'result': 'error'}
 
     async def scan_files(self, to_scan):
         """
@@ -377,7 +377,7 @@ class PolyswarmAsyncAPI(object):
                     return result
             return await self.wait_for_results(results)
         except exceptions.PolyswarmAPIException as e:
-            return {'filename': str(e), 'files': []}
+            return {'filename': str(e), 'files': [], 'status': 'error', 'result': 'error'}
         finally:
             # attempt to close files if they were opened, ignore errors if unable to close
             # they will later be garbage collected and properly closed if necessary

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -136,8 +136,6 @@ class PolyswarmAsyncAPI(object):
             # ignore if not complete
             return result
 
-        result['status'] = 'OK'
-
         return result
 
     async def check_version(self):

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -383,6 +383,54 @@ class PolyswarmAsyncAPI(object):
                 except:
                     pass
 
+    async def scan_fileobj(self, to_scan, filename='data'):
+        """
+        Scan a single file-like object using the PS API asynchronously.
+
+        :param to_scan: File-like object to scan.
+        :param filename: Filename to use
+        :return: JSON report
+        """
+        return await self.scan_fileobjs([(to_scan, filename)], artifact_type=ArtifactType.FILE)
+
+    async def scan_url(self, to_scan, name='url'):
+        """
+        Scan a single URL using the PS API synchronously
+
+        :param to_scan: URL to scan
+        :param name: name to associate with the artifact
+        :return: JSON report
+        """
+        return await self.scan_urls([to_scan])
+
+    async def scan_file(self, to_scan):
+        """
+        Scan a single file using the PS API synchronously.
+
+        :param to_scan: Path of file to scan.
+        :return: JSON report file
+        """
+        return await self.scan_files([to_scan])
+
+    async def post_url(self, url):
+        """
+        POST URL to the PS API to be scanned synchronously
+
+        :param url: URL to scan
+        :return: Dictionary of the result code and the UUID of the scan (if successful)
+        """
+        return await self.scan_urls([url])
+
+    async def post_file(self, file_obj, filename):
+        """
+        POST file to the PS API to be scanned synchronously.
+
+        :param file_obj: File-like object to POST to the API
+        :param filename: Name of file to be given to the API
+        :return: Dictionary of the result code and the UUID of the upload (if successful)
+        """
+        return await self.scan_fileobjs([(file_obj, filename)], artifact_type=ArtifactType.FILE)
+
     async def scan_directory(self, directory, recursive=False):
         """
         Scan a directory using the PS API asynchronously.

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -136,6 +136,8 @@ class PolyswarmAsyncAPI(object):
             # ignore if not complete
             return result
 
+        result['status'] = 'OK'
+
         return result
 
     async def check_version(self):

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1000,7 +1000,7 @@ class PolyswarmAPI(object):
 
     def scan_fileobj(self, to_scan, filename='data'):
         """
-        Scan a single file-like object using the PS API asynchronously.
+        Scan a single file-like object using the PS API synchronously.
 
         :param to_scan: File-like object to scan.
         :param filename: Filename to use
@@ -1010,7 +1010,7 @@ class PolyswarmAPI(object):
 
     def scan_data(self, data):
         """
-        Scan bytes using the PS API asynchronously.
+        Scan bytes using the PS API synchronously.
         :param data: Data (in bytes) to submit to be scanned
         :return: JSON report
         """
@@ -1077,7 +1077,7 @@ class PolyswarmAPI(object):
 
     def search_hash(self, to_scan, hash_type='sha256'):
         """
-        Scan a single hash using the PS API asynchronously.
+        Scan a single hash using the PS API synchronously.
 
         :param to_scan:
         :param hash_type: Hash type [sha256|sha1|md5]
@@ -1088,7 +1088,7 @@ class PolyswarmAPI(object):
 
     def search_query(self, query, raw=True):
         """
-        Search by Elasticsearch query using the PS API asynchronously.
+        Search by Elasticsearch query using the PS API synchronously.
 
         :param query: Elasticsearch JSON query or search string
         :param raw: If true, treated as ES JSON query. If false, treated as an ES query_string

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -945,14 +945,25 @@ class PolyswarmAPI(object):
         """
         return self.loop.run_until_complete(self.ps_api.get_file_data(sha256))
 
-    def scan_fileobjs(self, to_scan):
+    def scan_fileobj(self, to_scan, filename='data'):
         """
-        Scan a collection of file-like object using the PS API asynchronously.
+        Scan a single file-like object using the PS API asynchronously.
 
-        :param to_scan: A list of (file-like object, filename) tuples to scan.
+        :param to_scan: File-like object to scan.
+        :param filename: Filename to use
         :return: JSON report
         """
-        return self.loop.run_until_complete(self.ps_api.scan_fileobjs(to_scan))
+        return self.loop.run_until_complete(self.ps_api.scan_fileobj(to_scan, filename))
+
+    def scan_file(self, to_scan):
+        """
+        Scan a single file using the PS API synchronously.
+
+        :param to_scan: Path of file to scan.
+        :return: JSON report file
+        """
+
+        return self.loop.run_until_complete(self.ps_api.scan_file(to_scan))
 
     def scan_files(self, files):
         """
@@ -962,6 +973,16 @@ class PolyswarmAPI(object):
         :return: JSON report file
         """
         return self.loop.run_until_complete(self.ps_api.scan_files(files))
+
+    def scan_url(self, to_scan, name='url'):
+        """
+        Scan a single URL using the PS API synchronously
+
+        :param to_scan: URL to scan
+        :param name: name to associate with the artifact
+        :return: JSON report
+        """
+        return self.loop.run_until_complete(self.ps_api.scan_url(to_scan, name))
 
     def scan_urls(self, to_scan):
         """
@@ -1031,6 +1052,25 @@ class PolyswarmAPI(object):
         :return: JSON report file
         """
         return self.loop.run_until_complete(self.ps_api.lookup_uuids(uuids))
+
+    def post_file(self, file_obj, filename):
+        """
+        POST file to the PS API to be scanned synchronously.
+
+        :param file_obj: File-like object to POST to the API
+        :param filename: Name of file to be given to the API
+        :return: Dictionary of the result code and the UUID of the upload (if successful)
+        """
+        return self.loop.run_until_complete(self.ps_api.post_file(file_obj, filename))
+
+    def post_url(self, url):
+        """
+        POST URL to the PS API to be scanned synchronously
+
+        :param url: URL to scan
+        :return: Dictionary of the result code and the UUID of the scan (if successful)
+        """
+        return self.loop.run_until_complete(self.ps_api.post_url(url))
 
     def download_file(self, h, destination_dir, with_metadata=False, hash_type='sha256'):
         """

--- a/src/polyswarm_api/exceptions.py
+++ b/src/polyswarm_api/exceptions.py
@@ -1,0 +1,14 @@
+class PolyswarmAPIException(Exception):
+    pass
+
+
+class RequestFailedException(PolyswarmAPIException):
+    pass
+
+
+class BadFormatException(PolyswarmAPIException):
+    pass
+
+
+class ServerErrorException(PolyswarmAPIException):
+    pass

--- a/test/client/client_scan_test.py
+++ b/test/client/client_scan_test.py
@@ -93,25 +93,25 @@ class ScanTestCase(TestCase):
         client = PolyswarmAPI(self.test_api_key)
         urls = ['google.com', 'polyswarm.io']
         error_msg = ', '.join(urls)
-        with mock.patch('polyswarm_api.PolyswarmAsyncAPI.post_artifacts',
+        with mock.patch('polyswarm_api.PolyswarmAsyncAPI._post_artifacts',
                         side_effect=exceptions.RequestFailedException(error_msg)):
             results = client.scan_urls(urls)
-            assert results == {'filename': error_msg, 'files': []}
+            assert results == {'filename': error_msg, 'files': [], 'result': 'error', 'status': 'error'}
 
     def test_file_request_failed_exception(self):
         client = PolyswarmAPI(self.test_api_key)
         with temp_dir({'test1': '123', 'test2': '456'}) as (_, files):
             error_msg = ', '.join(files)
-            with mock.patch('polyswarm_api.PolyswarmAsyncAPI.post_artifacts',
+            with mock.patch('polyswarm_api.PolyswarmAsyncAPI._post_artifacts',
                             side_effect=exceptions.RequestFailedException(error_msg)):
                 results = client.scan_files(files)
-                assert results == {'filename': error_msg, 'files': []}
+                assert results == {'filename': error_msg, 'files': [], 'result': 'error', 'status': 'error'}
 
     def test_file_request_successful(self):
         client = PolyswarmAPI(self.test_api_key)
         with temp_dir({'test1': '123', 'test2': '456'}) as (_, files):
             with mock.patch(
-                    'polyswarm_api.PolyswarmAsyncAPI.post_artifacts',
+                    'polyswarm_api.PolyswarmAsyncAPI._post_artifacts',
                     return_value=async_return({
                         'status': 'OK',
                         'result': '00000000-0000-0000-0000-000000000000'})
@@ -126,7 +126,7 @@ class ScanTestCase(TestCase):
         client = PolyswarmAPI(self.test_api_key)
         urls = ['google.com', 'polyswarm.io']
         with mock.patch(
-                'polyswarm_api.PolyswarmAsyncAPI.post_artifacts',
+                'polyswarm_api.PolyswarmAsyncAPI._post_artifacts',
                 return_value=async_return({
                     'status': 'OK',
                     'result': '00000000-0000-0000-0000-000000000000'})

--- a/test/client/client_scan_test.py
+++ b/test/client/client_scan_test.py
@@ -1,0 +1,138 @@
+import os
+import tempfile
+from contextlib import contextmanager
+import asyncio
+
+from polyswarm_api import PolyswarmAPI
+from polyswarm_api import exceptions
+from unittest import TestCase, mock
+
+FILE_SUBMISSION_RESULT = {
+    'files': [
+        {
+            'assertions': [
+                {
+                    'author': '0x0000000000000000000000000000000000000000',
+                    'bid': 500000000000000000,
+                    'engine': '0x0000000000000000000000000000000000000000',
+                    'mask': True,
+                    'metadata': {'malware_family': '',
+                                 'scanner': {'environment': {'architecture': 'x86_64',
+                                                             'operating_system': 'Linux'}}},
+                    'verdict': False
+                }
+            ],
+            'bounty_guid': '00000000-0000-0000-0000-000000000001',
+            'bounty_status': 'Awaiting arbitration.',
+            'failed': False,
+            'filename': 'test1',
+            'hash': '0000000000000000000000000000000000000000000000000000000000000000',
+            'result': None,
+            'size': 3,
+            'submission_guid': '00000000-0000-0000-0000-000000000000',
+            'votes': [],
+            'window_closed': True
+        },
+        {'assertions': [
+            {
+                'author': '0x0000000000000000000000000000000000000000',
+                'bid': 500000000000000000,
+                'engine': '0x0000000000000000000000000000000000000000',
+                'mask': True,
+                'metadata': {'malware_family': 'Test File',
+                             'scanner': {'environment': {'architecture': 'x86_64',
+                                                         'operating_system': 'Linux'}}},
+                'verdict': True
+            }
+        ],
+            'bounty_guid': '00000000-0000-0000-0000-000000000002',
+            'bounty_status': 'Awaiting arbitration.',
+            'failed': False,
+            'filename': 'test2',
+            'hash': '0000000000000000000000000000000000000000000000000000000000000000',
+            'result': None,
+            'size': 3,
+            'submission_guid': '00000000-0000-0000-0000-000000000000',
+            'votes': [],
+            'window_closed': True
+        }
+    ],
+    'forced': True,
+    'permalink': 'https://polyswarm.network/scan/results/00000000-0000-0000-0000-000000000000',
+    'status': 'OK',
+    'uuid': '00000000-0000-0000-0000-000000000000'
+}
+
+URL_SUBMISSION_RESULT = FILE_SUBMISSION_RESULT
+
+
+def async_return(result):
+    f = asyncio.Future()
+    f.set_result(result)
+    return f
+
+
+@contextmanager
+def test_dir(files_dict):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        files = []
+        for file_name, file_content in files_dict.items():
+            mode = 'w' if isinstance(file_content, str) else 'wb'
+            file_path = os.path.join(tmp_dir, file_name)
+            open(file_path, mode=mode).write(file_content)
+            files.append(file_path)
+        yield tmp_dir, files
+
+
+class ScanTestCase(TestCase):
+    def __init__(self, *args, **kwargs):
+        super(ScanTestCase, self).__init__(*args, **kwargs)
+        self.test_api_key = '00000000000000000000000000000000'
+
+    def test_url_request_failed_exception(self):
+        client = PolyswarmAPI(self.test_api_key)
+        urls = ['google.com', 'polyswarm.io']
+        error_msg = ', '.join(urls)
+        with mock.patch('polyswarm_api.PolyswarmAsyncAPI.post_artifacts',
+                        side_effect=exceptions.RequestFailedException(error_msg)):
+            results = client.scan_urls(urls)
+            assert results == {'filename': error_msg, 'files': []}
+
+    def test_file_request_failed_exception(self):
+        client = PolyswarmAPI(self.test_api_key)
+        with test_dir({'test1': '123', 'test2': '456'}) as (_, files):
+            error_msg = ', '.join(files)
+            with mock.patch('polyswarm_api.PolyswarmAsyncAPI.post_artifacts',
+                            side_effect=exceptions.RequestFailedException(error_msg)):
+                results = client.scan_files(files)
+                assert results == {'filename': error_msg, 'files': []}
+
+    def test_file_request_successful(self):
+        client = PolyswarmAPI(self.test_api_key)
+        with test_dir({'test1': '123', 'test2': '456'}) as (_, files):
+            with mock.patch(
+                    'polyswarm_api.PolyswarmAsyncAPI.post_artifacts',
+                    return_value=async_return({
+                        'status': 'OK',
+                        'result': '00000000-0000-0000-0000-000000000000'})
+            ), mock.patch(
+                'polyswarm_api.PolyswarmAsyncAPI.lookup_uuid',
+                return_value=async_return(FILE_SUBMISSION_RESULT)
+            ):
+                results = client.scan_files(files)
+                assert results == [FILE_SUBMISSION_RESULT]
+
+    def test_url_request_successful(self):
+        client = PolyswarmAPI(self.test_api_key)
+        urls = ['google.com', 'polyswarm.io']
+        with mock.patch(
+                'polyswarm_api.PolyswarmAsyncAPI.post_artifacts',
+                return_value=async_return({
+                    'status': 'OK',
+                    'result': '00000000-0000-0000-0000-000000000000'})
+        ), mock.patch(
+            'polyswarm_api.PolyswarmAsyncAPI.lookup_uuid',
+            return_value=async_return(URL_SUBMISSION_RESULT)
+        ):
+            results = client.scan_urls(urls)
+            assert results == [URL_SUBMISSION_RESULT]

--- a/test/client/client_scan_test.py
+++ b/test/client/client_scan_test.py
@@ -73,7 +73,7 @@ def async_return(result):
 
 
 @contextmanager
-def test_dir(files_dict):
+def temp_dir(files_dict):
     with tempfile.TemporaryDirectory() as tmp_dir:
         files = []
         for file_name, file_content in files_dict.items():
@@ -100,7 +100,7 @@ class ScanTestCase(TestCase):
 
     def test_file_request_failed_exception(self):
         client = PolyswarmAPI(self.test_api_key)
-        with test_dir({'test1': '123', 'test2': '456'}) as (_, files):
+        with temp_dir({'test1': '123', 'test2': '456'}) as (_, files):
             error_msg = ', '.join(files)
             with mock.patch('polyswarm_api.PolyswarmAsyncAPI.post_artifacts',
                             side_effect=exceptions.RequestFailedException(error_msg)):
@@ -109,7 +109,7 @@ class ScanTestCase(TestCase):
 
     def test_file_request_successful(self):
         client = PolyswarmAPI(self.test_api_key)
-        with test_dir({'test1': '123', 'test2': '456'}) as (_, files):
+        with temp_dir({'test1': '123', 'test2': '456'}) as (_, files):
             with mock.patch(
                     'polyswarm_api.PolyswarmAsyncAPI.post_artifacts',
                     return_value=async_return({


### PR DESCRIPTION
This modification enables the client to submit multiple artifacts (files or urls) in a single post request to the api.

- Modifications in command line client to send multiple files in a single post request (up to 256 files per post request).
- Using exceptions to treat failure responses from the API
- Adding unit test to submission methods
- Minor reorganization of submission methods so that they are more reusable.