### PR TITLE
Fixing ignored bounty status from the API

### DIFF
--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -300,7 +300,7 @@ class PolyswarmAsyncAPI(object):
         while True:
             result = await self.lookup_uuid(uuid)
 
-            if result.get('status', 'error') == 'error':
+            if result.get('status', 'Bounty Failed') == 'Bounty Failed':
                 return result
 
             if self._reveal_closed(result):

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -136,8 +136,6 @@ class PolyswarmAsyncAPI(object):
             # ignore if not complete
             return result
 
-        result['status'] = 'OK'
-
         return result
 
     async def check_version(self):

--- a/src/polyswarm_api/formatting.py
+++ b/src/polyswarm_api/formatting.py
@@ -111,7 +111,7 @@ class PSResultFormatter(object):
                                                         extended_type=file_info['extended_type'],
                                                         filenames=','.join(set(file_info['filenames'])))))
                     if 'assertions' not in f or len(f['assertions']) == 0:
-                        if 'failed' in f and f['failed']:
+                        if result['status'] == 'Bounty Failed' or ('failed' in f and f['failed']):
                             output.append(self._bad('Bounty failed, please resubmit'))
                         elif 'window_closed' in f and f['window_closed']:
                             output.append(self._warn('Bounty closed without any engine assertions. Try again later.'))


### PR DESCRIPTION
Client was overwriting the `status` returned by the API for the bounty. Do not do this anymore. Also print an error in case the bounty failed.

Work made on top of https://github.com/polyswarm/polyswarm-api/pull/53, should be merged after that (pointing to branch to make reviews easier, should change to develop before merging).