### PR TITLE
Using engine names returned from the api

### DIFF
--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -114,31 +114,6 @@ class PolyswarmAsyncAPI(object):
         """
         self.timeout = timeout
 
-    def _fix_result(self, result):
-        """
-        For now, since the name-ETH address mappings are not added by consumer, we add them using
-        a hardcoded dict. This function does that for us. It also adds in a permalink to the scan.
-        These changes will be moved into consumer soon.
-
-        :param result: The JSON we got from consumer API
-        :return: JSON updated with name-ETH address mappings for microengines and arbiters
-        """
-        if 'uuid' in result:
-            result['permalink'] = self.portal_uri + result['uuid']
-        try:
-            for file in result['files']:
-                if 'assertions' in file:
-                    for assertion in file['assertions']:
-                        assertion['engine'] = self.engine_resolver.get_engine_name(assertion['author'])
-                if 'votes' in file:
-                    for vote in file['votes']:
-                        vote['engine'] = self.engine_resolver.get_engine_name(vote['arbiter'])
-        except KeyError:
-            # ignore if not complete
-            return result
-
-        return result
-
     async def check_version(self):
         """
         Checks GitHub to see if you have the latest version installed.
@@ -279,7 +254,7 @@ class PolyswarmAsyncAPI(object):
                                 return {'files': [], 'uuid': uuid}
                             logger.error('Error reading from PolySwarm API: %s', errors)
                             return {'files': [], 'uuid': uuid}
-                        return self._fix_result(response['result'])
+                        return response['result']
                 except Exception:
                     logger.error('Server request failed')
                     return {'reason': 'unknown_error', 'status': 'error', 'uuid': uuid}

--- a/src/polyswarm_api/formatting.py
+++ b/src/polyswarm_api/formatting.py
@@ -119,14 +119,15 @@ class PSResultFormatter(object):
                             output.append(self._normal('Scan still in progress, please check again later.'))
                     else:
                         for assertion in f['assertions']:
+                            engine_name = assertion['engine'].get('name', assertion['author'])
                             if assertion['verdict'] is False:
-                                response_counts[assertion['engine']] = response_counts.get(assertion['engine'], 0) + 1
-                                output.append('%s: %s' % (self._normal(assertion['engine']), self._good('Clean')))
+                                response_counts[engine_name] = response_counts.get(engine_name, 0) + 1
+                                output.append('%s: %s' % (self._normal(engine_name), self._good('Clean')))
                             elif assertion['verdict'] is None or assertion['mask'] is False:
-                                output.append('%s: %s' % (self._normal(assertion['engine']), self._unknown('Unknown/failed to respond')))
+                                output.append('%s: %s' % (self._normal(engine_name), self._unknown('Unknown/failed to respond')))
                             else:
-                                response_counts[assertion['engine']] = response_counts.get(assertion['engine'], 0) + 1
-                                output.append('%s: %s' % (self._normal(assertion['engine']),
+                                response_counts[engine_name] = response_counts.get(engine_name, 0) + 1
+                                output.append('%s: %s' % (self._normal(engine_name),
                                                           self._bad('Malicious') +
                                                           (self._bad(', metadata: %s' % assertion['metadata'])
                                                           if 'metadata' in assertion and assertion['metadata'] is not None else '')))


### PR DESCRIPTION
`polyswarm-api` does not change the results from the api and the formatting methods use the engine name provided from the api if available.