### PR TITLE
requests version update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests~=2.20
+requests>=2.20
 pytest==3.9.2
 jsonschema==3.0.2
 ordered-set==3.1.1


### PR DESCRIPTION
`~=` version derives in error while installing from requirements.txt in python3.6: 

error: requests 2.23.0 is installed but requests~=2.22.0 is required by {'polyswarm-api'}