### PR TITLE
printing message from the api, making errors more meaningful

### DIFF
--- a/src/polyswarm_api/const.py
+++ b/src/polyswarm_api/const.py
@@ -34,8 +34,3 @@ MAX_OPEN_FDS = 256
 DOWNLOAD_CHUNK_SIZE = 1024*1024*4
 
 MAX_SINCE_TIME_STREAM = 2 * 60 * 24
-
-USAGE_EXCEEDED_MESSAGE = 'Usage limits were exceeded. This may mean you need to purchase a ' \
-                         'larger package, or that you have exceeded rate limits.\n' \
-                         'If you continue to have issues, please contact us at info@polyswarm.io.'
-

--- a/src/polyswarm_api/endpoint.py
+++ b/src/polyswarm_api/endpoint.py
@@ -87,7 +87,10 @@ class PolyswarmRequest(object):
             if self.status_code // 100 != 2:
                 self._extract_json_body(result)
                 if self.status_code == 429:
-                    raise exceptions.UsageLimitsExceededException(self, const.USAGE_EXCEEDED_MESSAGE)
+                    message = f'{self.result} This may mean you need to purchase a ' \
+                              'larger package, or that you have exceeded rate limits. ' \
+                              'If you continue to have issues, please contact us at info@polyswarm.io.'
+                    raise exceptions.UsageLimitsExceededException(self, message)
                 if self.status_code == 404:
                     raise exceptions.NotFoundException(self, self.result)
                 raise exceptions.RequestException(self, self._bad_status_message())

--- a/src/polyswarm_api/endpoint.py
+++ b/src/polyswarm_api/endpoint.py
@@ -87,9 +87,10 @@ class PolyswarmRequest(object):
             if self.status_code // 100 != 2:
                 self._extract_json_body(result)
                 if self.status_code == 429:
-                    message = f'{self.result} This may mean you need to purchase a ' \
-                              'larger package, or that you have exceeded rate limits. ' \
-                              'If you continue to have issues, please contact us at info@polyswarm.io.'
+                    message = '{} This may mean you need to purchase a ' \
+                              'larger package, or that you have exceeded ' \
+                              'rate limits. If you continue to have issues, ' \
+                              'please contact us at info@polyswarm.io.'.format(self.result)
                     raise exceptions.UsageLimitsExceededException(self, message)
                 if self.status_code == 404:
                     raise exceptions.NotFoundException(self, self.result)


### PR DESCRIPTION
429 responses were not logging the api message. Fixing that.