### PR TITLE
Avoid leaking handles when exceptions occur

### DIFF
--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -494,6 +494,7 @@ class PolyswarmAPI(object):
             self.generator.download(hash_.hash, hash_.hash_type, handle=artifact).execute()
         except Exception as e:
             artifact.handle.close()
+            os.remove(path)
             raise e
 
         return artifact
@@ -514,6 +515,7 @@ class PolyswarmAPI(object):
             self.generator.download_archive(s3_path, handle=artifact).execute()
         except Exception as e:
             artifact.handle.close()
+            os.remove(path)
             raise e
 
         return artifact

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -493,9 +493,10 @@ class PolyswarmAPI(object):
         try:
             self.generator.download(hash_.hash, hash_.hash_type, handle=artifact).execute()
         except Exception as e:
-            artifact.handle.close()
             os.remove(path)
             raise e
+        finally:
+            artifact.handle.close()
 
         return artifact
 
@@ -514,9 +515,10 @@ class PolyswarmAPI(object):
         try:
             self.generator.download_archive(s3_path, handle=artifact).execute()
         except Exception as e:
-            artifact.handle.close()
             os.remove(path)
             raise e
+        finally:
+            artifact.handle.close()
 
         return artifact
 

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -494,9 +494,10 @@ class PolyswarmAPI(object):
             self.generator.download(hash_.hash, hash_.hash_type, handle=artifact).execute()
         except Exception as e:
             os.remove(path)
-            raise e
-        finally:
             artifact.handle.close()
+            raise e
+
+        artifact.handle.close()
 
         return artifact
 
@@ -516,9 +517,10 @@ class PolyswarmAPI(object):
             self.generator.download_archive(s3_path, handle=artifact).execute()
         except Exception as e:
             os.remove(path)
-            raise e
-        finally:
             artifact.handle.close()
+            raise e
+
+        artifact.handle.close()
 
         return artifact
 

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -489,8 +489,13 @@ class PolyswarmAPI(object):
         hash_ = resources.Hash.from_hashable(hash_, hash_type=hash_type)
         path = os.path.join(out_dir, hash_.hash)
         artifact = resources.LocalArtifact.from_path(self, path, create=True)
-        self.generator.download(hash_.hash, hash_.hash_type, handle=artifact).execute()
-        artifact.handle.close()
+
+        try:
+            self.generator.download(hash_.hash, hash_.hash_type, handle=artifact).execute()
+        except Exception as e:
+            artifact.handle.close()
+            raise e
+
         return artifact
 
     def download_archive(self, out_dir, s3_path):
@@ -504,8 +509,13 @@ class PolyswarmAPI(object):
         logger.info('Downloading %s into %s', s3_path, out_dir)
         path = os.path.join(out_dir, os.path.basename(urlparse(s3_path).path))
         artifact = resources.LocalArtifact.from_path(self, path, create=True)
-        self.generator.download_archive(s3_path, handle=artifact).execute()
-        artifact.handle.close()
+
+        try:
+            self.generator.download_archive(s3_path, handle=artifact).execute()
+        except Exception as e:
+            artifact.handle.close()
+            raise e
+
         return artifact
 
     def download_to_handle(self, hash_, fh, hash_type=None):


### PR DESCRIPTION
This ensures we close the file handles for downloading files if an exception occurs, and removes the failed files. This PR leaves `download_to_handle` as it is, as the caller is responsible for that handle.