### PR TITLE
Fix submit() when using file-like objects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md', 'r') as readme:
 
 setup(
     name='polyswarm-api',
-    version='2.1.0',
+    version='2.1.1',
     description='Client library to simplify interacting with the PolySwarm consumer API',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/polyswarm_api/_version.py
+++ b/src/polyswarm_api/_version.py
@@ -1,4 +1,4 @@
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -114,12 +114,13 @@ class PolyswarmAPI(object):
         logger.info('Searching for metadata %s', query)
         return self.generator.search_metadata(query).execute().consume_results()
 
-    def submit(self, artifact, artifact_type=resources.ArtifactType.FILE):
+    def submit(self, artifact, artifact_type=resources.ArtifactType.FILE, artifact_name=None):
         """
         Submit artifacts to polyswarm and return UUIDs
 
         :param artifact: A file-like, path to file, url or LocalArtifact instance
         :param artifact_type: The ArtifactType or strings containing "file" or "url"
+        :param artifact_name: An appropriate filename for the Artifact
         :return: An ArtifactInstance resource
         """
         logger.info('Submitting artifact of type %s', artifact_type)
@@ -128,12 +129,14 @@ class PolyswarmAPI(object):
         #  to isinstance(artifact, io.IOBase) when deprecating 2.7 and implementing making LocalHandle
         #  inherit io.IOBase, although this will change the method delegation logic in the resource
         if hasattr(artifact, 'read') and hasattr(artifact.read, '__call__'):
-            artifact = resources.LocalArtifact(artifact, artifact_type=artifact_type, polyswarm=self, analyze=False)
+            artifact = resources.LocalArtifact(artifact, artifact_type=artifact_type, polyswarm=self, analyze=False,
+                                               artifact_name=artifact_name)
         elif isinstance(artifact, string_types):
             if artifact_type == resources.ArtifactType.FILE:
-                artifact = resources.LocalArtifact.from_path(self, artifact, artifact_type=artifact_type)
+                artifact = resources.LocalArtifact.from_path(self, artifact, artifact_type=artifact_type,
+                                                             artifact_name=artifact_name)
             elif artifact_type == resources.ArtifactType.URL:
-                artifact = resources.LocalArtifact.from_content(self, artifact, artifact_name=artifact,
+                artifact = resources.LocalArtifact.from_content(self, artifact, artifact_name=artifact_name or artifact,
                                                                 artifact_type=artifact_type)
         if isinstance(artifact, resources.LocalArtifact):
             return self.generator.submit(artifact, artifact.artifact_name, artifact.artifact_type.name).execute().result

--- a/src/polyswarm_api/types/resources.py
+++ b/src/polyswarm_api/types/resources.py
@@ -48,7 +48,7 @@ class Metadata(base.BasePSJSONType, base.AsInteger):
         self.sha1 = self.artifact.get('sha1')
         self.sha256 = self.artifact.get('sha256')
         self.md5 = self.artifact.get('md5')
-        
+
         self.ssdeep = self.hash.get('ssdeep')
         self.tlsh = self.hash.get('tlsh')
 

--- a/src/polyswarm_api/types/resources.py
+++ b/src/polyswarm_api/types/resources.py
@@ -45,9 +45,10 @@ class Metadata(base.BasePSJSONType, base.AsInteger):
 
         self.id = self.artifact.get('id')
 
-        self.sha1 = self.hash.get('sha1')
-        self.sha256 = self.hash.get('sha256')
-        self.md5 = self.hash.get('md5')
+        self.sha1 = self.artifact.get('sha1')
+        self.sha256 = self.artifact.get('sha256')
+        self.md5 = self.artifact.get('md5')
+        
         self.ssdeep = self.hash.get('ssdeep')
         self.tlsh = self.hash.get('tlsh')
 

--- a/src/polyswarm_api/types/resources.py
+++ b/src/polyswarm_api/types/resources.py
@@ -211,11 +211,7 @@ class LocalHandle(base.BasePSResourceType):
         # Attribute lookups are delegated to the underlying file
         # and cached for non-numeric results
         # (i.e. methods are cached, closed and friends are not)
-        try:
-            a = getattr(self.handle, name)
-        except AttributeError:
-            # delegate to self if not found in the handle
-            return self.__dict__[name]
+        a = getattr(self.handle, name)
 
         if hasattr(a, '__call__'):
             func = a
@@ -242,12 +238,13 @@ class LocalArtifact(LocalHandle, base.Hashable):
         :param analyze: Boolean, if True will run analyses on artifact on startup (Note: this may still run later if False)
         """
         # create the LocalHandle with the given handle and don't write anything to it
+        super(LocalArtifact, self).__init__(b'', polyswarm=polyswarm, handle=handle)
+
         self.sha256 = None
         self.sha1 = None
         self.md5 = None
         self.analyzed = False
 
-        super(LocalArtifact, self).__init__(b'', polyswarm=polyswarm, handle=handle)
         self.artifact_type = artifact_type or ArtifactType.FILE
 
         self.artifact_name = artifact_name or os.path.basename(getattr(handle, 'name', '')) or str(self.hash)


### PR DESCRIPTION
Add `artifact_name` argument to API `submit` function and fix `artifact_name` resolution when passing file-like objects or `LocalArtifact` objects to submit.

This resolves DN-3821 and DN-3822.