### PR TITLE
Unpickle `BasePSResourceType` from '_json' rather than attr

### DIFF
--- a/src/polyswarm_api/types/base.py
+++ b/src/polyswarm_api/types/base.py
@@ -34,6 +34,9 @@ class BasePSJSONType(BasePSResourceType):
         if json is not None:
             self.json = json
 
+    def __reduce__(self):
+        return (type(self), (self.__dict__.get('_json'), self.polyswarm))
+
     @property
     def json(self):
         return self._json


### PR DESCRIPTION
Many test cases are made easier with pickled versions of various `PolyswarmAPI` resource objects.

The way `__init__` and `json` getter are written create an infinite loop when pickle attempts to unmarshal the object which this PR addresses.