### PR TITLE
Schema changes - part 2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.1
+current_version = 2.3.0
 commit = True
 tag = False
 sign_tags = True

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md', 'r') as readme:
 
 setup(
     name='polyswarm-api',
-    version='2.2.1',
+    version='2.3.0',
     description='Client library to simplify interacting with the PolySwarm consumer API',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '2.2.1'
+__version__ = '2.3.0'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -554,3 +554,11 @@ class PolyswarmAPI(object):
     def rerun_metadata(self, hashes, analyses=None, skip_es=None):
         logger.info('Rerunning metadata for hashes %s', hashes)
         return resources.ArtifactInstance.metadata_rerun(self, hashes, analyses=analyses, skip_es=skip_es).result()
+
+    def tool_metadata_create(self, sha256, tool, tool_metadata):
+        logger.info('Create tool metadata %s %s %s', sha256, tool, tool_metadata)
+        return resources.ToolMetadata.create(self, sha256=sha256, tool=tool, tool_metadata=tool_metadata).result()
+
+    def tool_metadata_list(self, sha256):
+        logger.info('List tool metadata')
+        return resources.ToolMetadata.list(self, sha256=sha256).result()

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -83,7 +83,7 @@ class ArtifactInstance(core.BaseJsonResource, core.Hashable):
                                                hash_value=content['sha256'], hash_type='sha256')
         # Artifact fields
         self.sha256 = content['sha256']
-        self.artifact_id = content['artifact_id']
+        self.artifact_id = content.get('artifact_id')
         self.md5 = content['md5']
         self.sha1 = content['sha1']
         self.mimetype = content['mimetype']
@@ -91,8 +91,8 @@ class ArtifactInstance(core.BaseJsonResource, core.Hashable):
         self.extended_type = content['extended_type']
         self.first_seen = core.parse_isoformat(content['first_seen'])
         # Deprecated
-        self.last_seen = core.parse_isoformat(content['last_seen'])
-        self.last_scanned = core.parse_isoformat(content['last_scanned'])
+        self.last_seen = core.parse_isoformat(content.get('last_seen'))
+        self.last_scanned = core.parse_isoformat(content.get('last_scanned'))
         metadata_json = content.get('metadata') or []
         metadata = {metadata['tool']: metadata['tool_metadata'] for metadata in metadata_json}
         self.metadata = Metadata(metadata, api)

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -35,6 +35,10 @@ class Engine(core.BaseJsonResource):
         return {'Authorization': None}
 
 
+class ToolMetadata(core.BaseJsonResource):
+    RESOURCE_ENDPOINT = '/artifact/metadata'
+
+
 class Metadata(core.BaseJsonResource):
     RESOURCE_ENDPOINT = '/search/metadata/query'
     KNOWN_KEYS = {'artifact', 'exiftool', 'hash', 'lief', 'pefile', 'scan', 'strings'}


### PR DESCRIPTION
- `artifact_id` is not returned anymore in instance serialization
- adding methods to post metadata (new `ai` routes for external analyzers)