### PR TITLE
`parse_result` should show the non-JSON response result

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.6.1
+current_version = 2.6.2
 commit = True
 tag = False
 sign_tags = True
@@ -21,4 +21,3 @@ search = version='{current_version}'
 replace = version='{new_version}'
 
 [bumpversion:file:src/polyswarm_api/__init__.py]
-

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md', 'r') as readme:
 
 setup(
     name='polyswarm-api',
-    version='2.6.1',
+    version='2.6.2',
     description='Client library to simplify interacting with the PolySwarm consumer API',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '2.6.1'
+__version__ = '2.6.2'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -585,3 +585,8 @@ class PolyswarmAPI(object):
     def tool_metadata_list(self, sha256):
         logger.info('List tool metadata')
         return resources.ToolMetadata.list(self, sha256=sha256).result()
+
+    def __repr__(self):
+        clsname = '{0.__module__}.{0.__name__}'.format(self.__class__)
+        attrs = 'uri={0.uri}, community={0.community}, timeout={0.timeout}'.format(self)
+        return '<{}({}) at 0x{:x}>'.format(clsname, attrs, id(self))

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -588,5 +588,5 @@ class PolyswarmAPI(object):
 
     def __repr__(self):
         clsname = '{0.__module__}.{0.__name__}'.format(self.__class__)
-        attrs = 'uri={0.uri}, community={0.community}, timeout={0.timeout}'.format(self)
+        attrs = 'uri={0.uri!r}, community={0.community!r}, timeout={0.timeout!r}'.format(self)
         return '<{}({}) at 0x{:x}>'.format(clsname, attrs, id(self))

--- a/src/polyswarm_api/core.py
+++ b/src/polyswarm_api/core.py
@@ -181,7 +181,7 @@ class PolyswarmRequest(object):
             if self.status_code == 404:
                 raise raise_from(exceptions.NotFoundException(self, 'The requested endpoint does not exist.'), e)
             else:
-                raise raise_from(exceptions.RequestException(self, 'Server returned non-JSON response.'), e)
+                raise raise_from(exceptions.RequestException(self, 'Server returned non-JSON response: %s' % result), e)
 
     def __iter__(self):
         return self.consume_results()

--- a/src/polyswarm_api/core.py
+++ b/src/polyswarm_api/core.py
@@ -181,7 +181,8 @@ class PolyswarmRequest(object):
             if self.status_code == 404:
                 raise raise_from(exceptions.NotFoundException(self, 'The requested endpoint does not exist.'), e)
             else:
-                raise raise_from(exceptions.RequestException(self, 'Server returned non-JSON response: %s' % result), e)
+                err_msg = 'Server returned non-JSON response [{}]: {}'.format(self.status_code, result)
+                raise raise_from(exceptions.RequestException(self, err_msg), e)
 
     def __iter__(self):
         return self.consume_results()


### PR DESCRIPTION
Also adds a `__repr__` implementation to `PolyswarmAPI`

```python
>>> repr(PolyswarmAPI(uri="https://api.polyswarm.network/v2", key=None))
<polyswarm_api.api.PolyswarmAPI(uri='https://api.polyswarm.network/v2', community='default', timeout=30) at 0x7f44f4529950>
```