### PR TITLE
add verify argument and accept requests.Session kwargs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.9.2
+current_version = 2.10.0
 commit = True
 tag = False
 sign_tags = True
@@ -21,4 +21,3 @@ search = version='{current_version}'
 replace = version='{new_version}'
 
 [bumpversion:file:src/polyswarm_api/__init__.py]
-

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md', 'r') as readme:
 
 setup(
     name='polyswarm-api',
-    version='2.9.2',
+    version='2.10.0',
     description='Client library to simplify interacting with the PolySwarm consumer API',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '2.9.2'
+__version__ = '2.10.0'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -18,18 +18,20 @@ logger = logging.getLogger(__name__)
 class PolyswarmAPI(object):
     """A synchronous interface to the public and private PolySwarm APIs."""
 
-    def __init__(self, key, uri=None, community=None, timeout=None):
+    def __init__(self, key, uri=None, community=None, timeout=None, verify=True, **kwargs):
         """
         :param key: PolySwarm API key
         :param uri: PolySwarm API URI
         :param community: Community to scan against.
         :param timeout: Maximum time to wait for an http response on every request.
+        :param verify: Boolean, whether or not to verify TLS connections.
+        :param **kwargs: Keyword args to pass to requests.Session
         """
         logger.info('Creating PolyswarmAPI instance: api_key: %s, api_uri: %s, community: %s', key, uri, community)
         self.uri = uri or settings.DEFAULT_GLOBAL_API
         self.community = community or settings.DEFAULT_COMMUNITY
         self.timeout = timeout or settings.DEFAULT_HTTP_TIMEOUT
-        self.session = polyswarm_api.core.PolyswarmSession(key, retries=settings.DEFAULT_RETRIES)
+        self.session = polyswarm_api.core.PolyswarmSession(key, retries=settings.DEFAULT_RETRIES, verify=verify, **kwargs)
         self._engines = None
 
     @property

--- a/src/polyswarm_api/core.py
+++ b/src/polyswarm_api/core.py
@@ -30,7 +30,6 @@ class PolyswarmSession(requests.Session):
             requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 
         self.verify = verify
-        self.trust_env = verify
 
         if key:
             self.set_auth(key)

--- a/src/polyswarm_api/core.py
+++ b/src/polyswarm_api/core.py
@@ -12,6 +12,7 @@ import requests
 from dateutil import parser
 from future.utils import raise_from
 from requests.adapters import HTTPAdapter
+from urllib3.exceptions import InsecureRequestWarning
 
 from polyswarm_api import settings, exceptions
 
@@ -19,10 +20,17 @@ logger = logging.getLogger(__name__)
 
 
 class PolyswarmSession(requests.Session):
-    def __init__(self, key, retries, user_agent=settings.DEFAULT_USER_AGENT):
-        super(PolyswarmSession, self).__init__()
+    def __init__(self, key, retries, user_agent=settings.DEFAULT_USER_AGENT, verify=True, **kwargs):
+        super(PolyswarmSession, self).__init__(**kwargs)
         logger.debug('Creating PolyswarmHTTP instance')
         self.requests_retry_session(retries=retries)
+
+        if not verify:
+            logger.warn('Disabling TLS verification for this session.')
+            requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+
+        self.verify = verify
+        self.trust_env = verify
 
         if key:
             self.set_auth(key)


### PR DESCRIPTION
Allow users to disable TLS verification, with a warning. Also allow them to pass keyword args to `requests.Session`.