### PR TITLE
Bump version: 3.5.1 → 3.5.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.5.1
+current_version = 3.5.2
 commit = True
 tag = False
 sign_tags = True

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md', 'r') as readme:
 
 setup(
     name='polyswarm-api',
-    version='3.5.1',
+    version='3.5.2',
     description='Client library to simplify interacting with the PolySwarm consumer API',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '3.5.1'
+__version__ = '3.5.2'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api


### PR DESCRIPTION
changelog:
   - new `sandbox_url` method

cli changes: https://github.com/polyswarm/polyswarm-cli/pull/159