### PR TITLE
fix: twine package upload issue caused by pkginfo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ release-pypi:
   stage: release
   before_script:
     - pip install -q --upgrade pip
-    - pip install setuptools~=79.0
+    - pip install setuptools~=79.0 pkginfo
     - pip install -q $END_TO_END_LIB@$CI_COMMIT_REF_NAME || pip install -q $END_TO_END_LIB
     - e2e init
   script:


### PR DESCRIPTION
Running into a new issue with Twine not uploading to pypi.  https://gitlab.ci.polyswarm.network/externalci/polyswarm-api/-/jobs/319063

Seems like it's a known issue https://github.com/pypi/warehouse/issues/15611.  Trying this based on the suggestions