### PR TITLE
Version 3.17.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,38 +1,14 @@
-image: $REPO_URL/stage
-
-stages:
-  - build
-  - test
-  - release
-
-variables:
-  DOCKER_HOST: tcp://localhost:2376
-  DOCKER_TLS_CERTDIR: "/certs"
-  DOCKER_TLS_VERIFY: 1
-  DOCKER_CERT_PATH: "$DOCKER_TLS_CERTDIR/client"
-
-default:
-  before_script:
-    - pip install -q --upgrade pip
-    - pip install -q $END_TO_END_LIB@$CI_COMMIT_REF_NAME || pip install -q $END_TO_END_LIB
-    - e2e init
+include:
+  - project: 'externalci/ci-image'
+    ref: master
+    file: '.gitlab-ci-default.yaml'
 
 ###############################################################
-# Build Stage (jobs inside a stage run in parallel)
+# Build Stage
 ###############################################################
 
 dev-pypi:
-  tags:
-    - stage-kube-newer
-  stage: build
-  before_script:
-    - pip3 install -q --upgrade pip build twine bump-my-version
-    - pip install -q $END_TO_END_LIB@$CI_COMMIT_REF_NAME || pip install -q $END_TO_END_LIB
-    - e2e init
-  script:
-    - bump-my-version bump --no-commit --no-tag dev
-    - python -m build
-    - e2e release --dev --skip-tag
+  extends: .dev-pypi
 
 ###############################################################
 # Test Stage
@@ -76,15 +52,4 @@ test-run312:
 ###############################################################
 
 release-pypi:
-  tags:
-    - stage-kube-newer
-  stage: release
-  script:
-    # release to internal pypi but do not tag yet
-    - e2e release --skip-tag --remote https://github.com/polyswarm/$CI_PROJECT_NAME.git
-    # release to public pypi and tag
-    - e2e release
-      -u "$PUBLIC_TWINE_USERNAME"
-      -p "$PUBLIC_TWINE_PASSWORD"
-      -r "$PUBLIC_TWINE_REPOSITORY_URL"
-      --remote "https://github.com/polyswarm/$CI_PROJECT_NAME.git"
+  extends: .release-pypi-public

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyswarm_api"
-version = "3.16.0"
+version = "3.17.0"
 description = "Client library to simplify interacting with the PolySwarm consumer API"
 readme = "README.md"
 requires-python = ">=3.10,<4"
@@ -42,7 +42,7 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.bumpversion]
-current_version = "3.16.0"
+current_version = "3.17.0"
 commit = true
 tag = false
 sign_tags = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyswarm_api"
-version = "3.17.0"
+version = "3.17.1"
 description = "Client library to simplify interacting with the PolySwarm consumer API"
 readme = "README.md"
 requires-python = ">=3.10,<4"
@@ -42,7 +42,7 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.bumpversion]
-current_version = "3.17.0"
+current_version = "3.17.1"
 commit = true
 tag = false
 sign_tags = true

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '3.17.0'
+__version__ = '3.17.1'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '3.16.0'
+__version__ = '3.17.0'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -957,6 +957,28 @@ class PolyswarmAPI:
         logger.info('List events')
         return resources.Events.list(self, **kwargs).result()
 
+    def sample(self, sha256, artifact_instance_id=None, sandbox_task_id_cape=None,
+               sandbox_task_id_triage=None, artifact_metadata_id=None):
+        """
+        Get aggregated sample information including artifact instance, sandbox tasks, and metadata.
+
+        :param sha256: SHA256 hash of the artifact
+        :param artifact_instance_id: Optional specific artifact instance ID
+        :param sandbox_task_id_cape: Optional specific Cape sandbox task ID
+        :param sandbox_task_id_triage: Optional specific Triage sandbox task ID
+        :param artifact_metadata_id: Optional specific artifact metadata ID
+        :return: A Sample resource with aggregated data
+        """
+        logger.info('Getting sample %s', sha256)
+        return resources.Sample.get(
+            self,
+            sha256=sha256,
+            artifact_instance_id=artifact_instance_id,
+            sandbox_task_id_cape=sandbox_task_id_cape,
+            sandbox_task_id_triage=sandbox_task_id_triage,
+            artifact_metadata_id=artifact_metadata_id,
+        ).result()
+
     def sample_bundle_task_create(self, instance_ids, preserve_filenames=False, filename=None, **kwargs):
         """
         Create a task that creates a zip of sample/s

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -1122,6 +1122,24 @@ class Events(core.BaseJsonResource):
         self.team_account_id = content['team_account_id']
         self.user_account_id = content['user_account_id']
 
+
+class Sample(core.BaseJsonResource):
+    RESOURCE_ENDPOINT = '/sample'
+    RESOURCE_ID_KEYS = ['sha256']
+
+    def __init__(self, content, api=None):
+        super().__init__(content, api=api)
+        self.artifact_instance = content.get('artifact_instance', {})
+        self.sandbox = content.get('sandbox', {})
+        self.metadata = content.get('metadata', {})
+
+    @classmethod
+    def _get_endpoint(cls, api, **kwargs):
+        sha256 = kwargs.pop('sha256', None)
+        if sha256:
+            return f'{api.uri}{cls.RESOURCE_ENDPOINT}/{sha256}'
+        return cls._endpoint(api, **kwargs)
+
 class BundleTask(core.BaseJsonResource):
     RESOURCE_ENDPOINT = "/bundle"
 

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -1132,6 +1132,7 @@ class Sample(core.BaseJsonResource):
         self.artifact_instance = content.get('artifact_instance', {})
         self.sandbox = content.get('sandbox', {})
         self.metadata = content.get('metadata', {})
+        self.pending = content.get('pending', {})
 
     @classmethod
     def _get_endpoint(cls, api, **kwargs):


### PR DESCRIPTION
### New Features

- __Added `Sample` resource__ — New `Sample` class in `resources.py` that aggregates artifact instance, sandbox task, and metadata information for a given sample, including a `pending` section for in-progress data.
- __Added `sample()` API method__ — New method on the API client (`api.py`) to fetch aggregated sample data by SHA256 hash, with optional filters for specific artifact instance ID, Cape/Triage sandbox task IDs, and artifact metadata ID.

### CI/CD

- __Refactored GitLab CI to use centralized templates__ — Replaced inline `dev-pypi` and `release-pypi` job definitions with `extends: .dev-pypi` and `extends: .release-pypi-public` from the shared `externalci/ci-image` CI template, removing ~35 lines of duplicated boilerplate (image, services, stages, variables, `before_script`).

### Version Bump

- Bumped version from __3.16.0__ → __3.17.1__ (`pyproject.toml`, `__init__.py`).
