### PR TITLE
chore: add .env and .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ _templates
 docker-compose.yaml
 e2e.yaml
 .envrc
+.env
+.venv


### PR DESCRIPTION
## TL;DR

- Add `.env` and `.venv` to `.gitignore` to prevent local environment files and virtual environments from being committed