### PR TITLE
feat(core): .jmespath() helper on BaseJsonResource

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 dependencies = [
   "requests>=2.31",
   "python-dateutil>=2.9",
+  "jmespath>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/polyswarm_api/core.py
+++ b/src/polyswarm_api/core.py
@@ -258,6 +258,27 @@ class BaseJsonResource(BaseResource):
             raise TypeError(f'Resource {type(self).__name__} does not have an id and can not be cast to int')
         return int(id_)
 
+    def jmespath(self, expr):
+        """Apply a JMESPath expression to this resource's underlying JSON.
+
+        Lets callers pull fields out of any API response without manual dotted-path
+        navigation or piping ``--fmt json`` CLI output through ``jq``. Uses JMESPath
+        syntax — see https://jmespath.org for the full grammar (no leading dot,
+        ``[*]`` projections, ``[?expr]`` filters, function calls, etc.).
+
+        Returns ``None`` when the expression resolves nothing in the document.
+
+        Example::
+
+            instance = api.lookup(scan_id)
+            polyscore = instance.jmespath("scan.latest_scan.polyscore")
+            mal_engines = instance.jmespath(
+                "scan.latest_scan.assertions[?verdict=='malicious'].engine.name"
+            )
+        """
+        import jmespath as _jmespath
+        return _jmespath.search(expr, self.json)
+
     def _get(self, path, default=None, content=None):
         """
         Helper for rendering attributes of child objects in the json that might be None.

--- a/test/jmespath_test.py
+++ b/test/jmespath_test.py
@@ -1,0 +1,72 @@
+"""Tests for BaseJsonResource.jmespath().
+
+Exercises the helper against synthetic content — the helper just delegates to
+jmespath.search(expr, self.json), so we don't need a real API response.
+"""
+
+from polyswarm_api.core import BaseJsonResource
+from polyswarm_api.resources import MetadataMapping
+
+
+def _resource(content):
+    return BaseJsonResource(content)
+
+
+def test_jmespath_simple_field():
+    r = _resource({"polyscore": 0.92})
+    assert r.jmespath("polyscore") == 0.92
+
+
+def test_jmespath_nested_dotted_path():
+    r = _resource({"scan": {"latest_scan": {"polyscore": 0.92}}})
+    assert r.jmespath("scan.latest_scan.polyscore") == 0.92
+
+
+def test_jmespath_returns_none_for_missing_path():
+    r = _resource({"a": {"b": 1}})
+    assert r.jmespath("a.c.d") is None
+    assert r.jmespath("nope") is None
+
+
+def test_jmespath_array_projection():
+    r = _resource({
+        "engines": [
+            {"name": "a"},
+            {"name": "b"},
+            {"name": "c"},
+        ],
+    })
+    assert r.jmespath("engines[*].name") == ["a", "b", "c"]
+
+
+def test_jmespath_filter_expression():
+    r = _resource({
+        "engines": [
+            {"name": "a", "verdict": "malicious"},
+            {"name": "b", "verdict": "benign"},
+            {"name": "c", "verdict": "malicious"},
+        ],
+    })
+    assert r.jmespath("engines[?verdict=='malicious'].name") == ["a", "c"]
+
+
+def test_jmespath_keys_function():
+    r = _resource({"foo": 1, "bar": 2, "baz": 3})
+    assert sorted(r.jmespath("keys(@)")) == ["bar", "baz", "foo"]
+
+
+def test_jmespath_length_function():
+    r = _resource({"engines": [1, 2, 3, 4, 5]})
+    assert r.jmespath("length(engines)") == 5
+
+
+def test_jmespath_works_on_subclass():
+    """Any BaseJsonResource subclass inherits .jmespath() automatically."""
+    m = MetadataMapping({"artifact": {"sha256": {"description": "hash"}}})
+    assert m.jmespath("artifact.sha256.description") == "hash"
+
+
+def test_jmespath_pipe():
+    """JMESPath pipe expressions work — | composes a sub-query on the previous result."""
+    r = _resource({"engines": [{"name": "z"}, {"name": "a"}, {"name": "m"}]})
+    assert r.jmespath("engines[*].name | sort(@)") == ["a", "m", "z"]


### PR DESCRIPTION
taken from https://github.com/polyswarm/polyswarm-api-private/pull/3

## Summary

Adds `.jmespath(expr)` to `BaseJsonResource` so callers can pull fields out of any API response with a JMESPath expression instead of piping `--fmt json` output through `jq`. The helper lives on the base class so every resource type (Metadata, ArtifactInstance, SandboxTask, MetadataMapping, etc.) gets it for free.

`pip install polyswarm-api` now pulls in `jmespath>=1.0`.

## What's in here

- **`BaseJsonResource.jmespath(expr)`** — one-line wrapper around `jmespath.search(expr, self.json)`. Returns `None` when the expression resolves nothing (mirrors `jmespath.search`'s default).
- **`pyproject.toml`** — `jmespath>=1.0` as a hard dep. ~50 KB; widely transitively present already.
- **9 new tests** covering dotted paths, array projections (`engines[*].name`), filter expressions (`[?verdict=='malicious']`), function calls (`keys(@)`, `length(...)`, `sort(@)`), pipe composition (`| sort(@)`), and inheritance through a subclass.

## Why JMESPath, not jq

- Pure-Python; no native `libjq` dep.
- Already standard in the AWS / shifty ecosystem (`aws --query`, `az --query`).
- Sufficient for "select fields from JSON". JQ is more powerful but heavier.
- See https://jmespath.org for the grammar.

## Why a separate branch from `feat/metadata-field-descriptions`

This is a cross-cutting helper on the base resource — it benefits every resource, not just metadata mappings. Splitting keeps each PR's review scope clean and lets either land independently.

## Usage

```python
instance = api.lookup(scan_id)

polyscore = instance.jmespath("scan.latest_scan.polyscore")
mal_engines = instance.jmespath(
    "scan.latest_scan.assertions[?verdict=='malicious'].engine.name"
)
top_level_keys = mapping.jmespath("keys(@)")
```

## Out of scope here

- CLI `--jmespath EXPR` flag on `polyswarm search …` — separate PR against `polyswarm-cli` once this lands.
- A `.jq()` companion for callers who want full JQ — would mean an optional `polyswarm-api[jq]` extra; defer until someone asks.
