### PR TITLE
feat(sample): switch to POST and send community in body

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyswarm_api"
-version = "3.19.1"
+version = "3.20.0"
 description = "Client library to simplify interacting with the PolySwarm consumer API"
 readme = "README.md"
 requires-python = ">=3.10,<4"
@@ -48,7 +48,7 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.bumpversion]
-current_version = "3.19.1"
+current_version = "3.20.0"
 commit = true
 tag = false
 sign_tags = true

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '3.19.1'
+__version__ = '3.20.0'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api

--- a/src/polyswarm_api/aio/__init__.py
+++ b/src/polyswarm_api/aio/__init__.py
@@ -1650,7 +1650,7 @@ class PolySwarmAsyncAPI:
         return await self._single(
             {
                 "method": "POST",
-                "url": f"{self.uri}{resources.Sample.RESOURCE_ENDPOINT}/{sha256}",
+                "url": f"{self.uri}{resources.Sample.RESOURCE_ENDPOINT.format(sha256=sha256)}",
                 "json": json_body,
             },
             result_parser=resources.Sample,

--- a/src/polyswarm_api/aio/__init__.py
+++ b/src/polyswarm_api/aio/__init__.py
@@ -1629,25 +1629,29 @@ class PolySwarmAsyncAPI:
         sandbox_task_id_cape=None,
         sandbox_task_id_triage=None,
         artifact_metadata_id=None,
+        llm_report_id=None,
     ):
-        """Get aggregated sample info (artifact instance + sandbox + metadata).
+        """Get aggregated sample info (artifact instance + sandbox + metadata + llm report).
 
-        Returns a Sample resource with .artifact_instance, .sandbox, .metadata, .pending.
+        Returns a Sample resource with .artifact_instance, .sandbox, .metadata, .pending,
+        .llm_report_task, .tasks.
         """
-        params = {}
+        json_body = {"community": self.community}
         if artifact_instance_id is not None:
-            params["artifact_instance_id"] = str(int(artifact_instance_id))
+            json_body["artifact_instance_id"] = str(int(artifact_instance_id))
         if sandbox_task_id_cape is not None:
-            params["sandbox_task_id_cape"] = str(int(sandbox_task_id_cape))
+            json_body["sandbox_task_id_cape"] = str(int(sandbox_task_id_cape))
         if sandbox_task_id_triage is not None:
-            params["sandbox_task_id_triage"] = str(int(sandbox_task_id_triage))
+            json_body["sandbox_task_id_triage"] = str(int(sandbox_task_id_triage))
         if artifact_metadata_id is not None:
-            params["artifact_metadata_id"] = str(int(artifact_metadata_id))
+            json_body["artifact_metadata_id"] = str(int(artifact_metadata_id))
+        if llm_report_id is not None:
+            json_body["llm_report_id"] = str(int(llm_report_id))
         return await self._single(
             {
-                "method": "GET",
+                "method": "POST",
                 "url": f"{self.uri}{resources.Sample.RESOURCE_ENDPOINT}/{sha256}",
-                "params": params or None,
+                "json": json_body,
             },
             result_parser=resources.Sample,
         )

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -959,25 +959,29 @@ class PolyswarmAPI:
         return resources.Events.list(self, **kwargs).result()
 
     def sample(self, sha256, artifact_instance_id=None, sandbox_task_id_cape=None,
-               sandbox_task_id_triage=None, artifact_metadata_id=None):
+               sandbox_task_id_triage=None, artifact_metadata_id=None, llm_report_id=None):
         """
-        Get aggregated sample information including artifact instance, sandbox tasks, and metadata.
+        Get aggregated sample information including artifact instance, sandbox tasks, metadata,
+        and LLM report.
 
         :param sha256: SHA256 hash of the artifact
         :param artifact_instance_id: Optional specific artifact instance ID
         :param sandbox_task_id_cape: Optional specific Cape sandbox task ID
         :param sandbox_task_id_triage: Optional specific Triage sandbox task ID
         :param artifact_metadata_id: Optional specific artifact metadata ID
+        :param llm_report_id: Optional specific LLM report task ID
         :return: A Sample resource with aggregated data
         """
         logger.info('Getting sample %s', sha256)
-        return resources.Sample.get(
+        return resources.Sample.create(
             self,
             sha256=sha256,
+            community=self.community,
             artifact_instance_id=artifact_instance_id,
             sandbox_task_id_cape=sandbox_task_id_cape,
             sandbox_task_id_triage=sandbox_task_id_triage,
             artifact_metadata_id=artifact_metadata_id,
+            llm_report_id=llm_report_id,
         ).result()
 
     def sample_bundle_task_create(self, instance_ids, preserve_filenames=False, filename=None, **kwargs):

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -975,7 +975,7 @@ class PolyswarmAPI:
         logger.info('Getting sample %s', sha256)
         return resources.Sample.create(
             self,
-            sha256=sha256,
+            endpoint_fmt={'sha256': sha256},
             community=self.community,
             artifact_instance_id=artifact_instance_id,
             sandbox_task_id_cape=sandbox_task_id_cape,

--- a/src/polyswarm_api/core.py
+++ b/src/polyswarm_api/core.py
@@ -293,10 +293,13 @@ class BaseJsonResource(BaseResource):
         return [cls.parse_result(api_instance, entry, **kwargs) for entry in json_data]
 
     @classmethod
-    def _endpoint(cls, api, **kwargs):
+    def _endpoint(cls, api, endpoint_fmt=None, **kwargs):
         if cls.RESOURCE_ENDPOINT is None:
             raise exceptions.InvalidValueException('RESOURCE_ENDPOINT is not configured for this resource.')
-        return '{api.uri}{endpoint}'.format(api=api, endpoint=cls.RESOURCE_ENDPOINT, **kwargs)
+        endpoint = cls.RESOURCE_ENDPOINT
+        if endpoint_fmt is not None:
+            endpoint = endpoint.format(**endpoint_fmt)
+        return '{api.uri}{endpoint}'.format(api=api, endpoint=endpoint, **kwargs)
 
     @classmethod
     def _list_endpoint(cls, api, **kwargs):
@@ -323,7 +326,7 @@ class BaseJsonResource(BaseResource):
         return cls._endpoint(api, **kwargs)
 
     @classmethod
-    def _params(cls, method, *param_keys, **kwargs):
+    def _params(cls, method, *param_keys, endpoint_fmt=None, **kwargs):
         params = {}
         json_params = {}
         for k, v in kwargs.items():

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -1125,7 +1125,7 @@ class Events(core.BaseJsonResource):
 
 
 class Sample(core.BaseJsonResource):
-    RESOURCE_ENDPOINT = '/sample'
+    RESOURCE_ENDPOINT = '/sample/{sha256}'
     RESOURCE_ID_KEYS = ['sha256']
 
     def __init__(self, content, api=None):
@@ -1136,23 +1136,6 @@ class Sample(core.BaseJsonResource):
         self.pending = content.get('pending', {})
         self.llm_report_task = content.get('llm_report_task')
         self.tasks = content.get('tasks')
-
-    @classmethod
-    def _get_endpoint(cls, api, **kwargs):
-        sha256 = kwargs.pop('sha256', None)
-        if sha256:
-            return f'{api.uri}{cls.RESOURCE_ENDPOINT}/{sha256}'
-        return cls._endpoint(api, **kwargs)
-
-    @classmethod
-    def _create_endpoint(cls, api, **kwargs):
-        sha256 = kwargs.get('sha256')
-        return f'{api.uri}{cls.RESOURCE_ENDPOINT}/{sha256}'
-
-    @classmethod
-    def _create_params(cls, **kwargs):
-        kwargs.pop('sha256', None)
-        return cls._params('POST', *cls.RESOURCE_ID_KEYS, **kwargs)
 
 class BundleTask(core.BaseJsonResource):
     RESOURCE_ENDPOINT = "/bundle"

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -1144,6 +1144,16 @@ class Sample(core.BaseJsonResource):
             return f'{api.uri}{cls.RESOURCE_ENDPOINT}/{sha256}'
         return cls._endpoint(api, **kwargs)
 
+    @classmethod
+    def _create_endpoint(cls, api, **kwargs):
+        sha256 = kwargs.get('sha256')
+        return f'{api.uri}{cls.RESOURCE_ENDPOINT}/{sha256}'
+
+    @classmethod
+    def _create_params(cls, **kwargs):
+        kwargs.pop('sha256', None)
+        return cls._params('POST', *cls.RESOURCE_ID_KEYS, **kwargs)
+
 class BundleTask(core.BaseJsonResource):
     RESOURCE_ENDPOINT = "/bundle"
 

--- a/test/async_client_test.py
+++ b/test/async_client_test.py
@@ -195,6 +195,18 @@ class TestAsyncScanCase:
         assert len(all_tasks) == 2
         assert {t.sandbox for t in all_tasks} == {'cape', 'triage'}
 
+    # ── Sample (aggregated view) ──────────────────────────────────────────────
+
+    @vcr.use_cassette()
+    async def test_async_sample(self):
+        async with self._api() as api:
+            result = await api.sample(SHA256)
+        assert isinstance(result.artifact_instance, dict)
+        assert isinstance(result.sandbox, dict)
+        assert {'cape', 'triage'} <= set(result.sandbox.keys())
+        assert isinstance(result.tasks, dict)
+        assert {'artifact_instance', 'llm_report', 'sandbox_cape', 'sandbox_triage'} <= set(result.tasks.keys())
+
     # ── YARA Rulesets ─────────────────────────────────────────────────────────
 
     @vcr.use_cassette()

--- a/test/client_scan_test.py
+++ b/test/client_scan_test.py
@@ -403,3 +403,13 @@ class ScanTestCaseV2(TestCase):
 
         assert len(tasks) == 2
         assert set(t.sandbox for t in tasks) == {'cape', 'triage'}
+
+    @vcr.use_cassette()
+    def test_sample(self):
+        api = PolyswarmAPI(self.test_api_key, uri=f'http://localhost:9696/{self.api_version}', community='gamma')
+        result = api.sample('275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f')
+        assert isinstance(result.artifact_instance, dict)
+        assert isinstance(result.sandbox, dict)
+        assert {'cape', 'triage'} <= set(result.sandbox.keys())
+        assert isinstance(result.tasks, dict)
+        assert {'artifact_instance', 'llm_report', 'sandbox_cape', 'sandbox_triage'} <= set(result.tasks.keys())

--- a/test/vcr/test_async_sample.vcr
+++ b/test/vcr/test_async_sample.vcr
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: '{"community":"gamma"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - '11111111111111111111111111111111'
+      connection:
+      - keep-alive
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      host:
+      - localhost:9696
+      user-agent:
+      - polyswarm_api/3.19.1 (x86_64-Linux-CPython-3.14.2)
+    method: POST
+    uri: http://localhost:9696/v3/sample/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
+  response:
+    body:
+      string: '{"result":{"artifact_instance":{},"llm_report_task":{},"metadata":{},"sandbox":{"cape":{},"triage":{}},"tasks":{"artifact_instance":{"rendered_id":null,"requested_id":null,"requested_status":null},"llm_report":{"rendered_id":null,"requested_id":null,"requested_status":null},"metadata":{"rendered_id":null,"requested_id":null,"requested_status":null},"sandbox_cape":{"rendered_id":null,"requested_id":null,"requested_status":null},"sandbox_triage":{"rendered_id":null,"requested_id":null,"requested_status":null}}},"status":"OK"}
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Authorization
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '530'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 06 May 2026 16:35:56 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '111'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/vcr/test_sample.vcr
+++ b/test/vcr/test_sample.vcr
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: '{"community": "gamma"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - polyswarm_api/3.19.1 (x86_64-Linux-CPython-3.14.2)
+    method: POST
+    uri: http://localhost:9696/v3/sample/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
+  response:
+    body:
+      string: '{"result":{"artifact_instance":{},"llm_report_task":{},"metadata":{},"sandbox":{"cape":{},"triage":{}},"tasks":{"artifact_instance":{"rendered_id":null,"requested_id":null,"requested_status":null},"llm_report":{"rendered_id":null,"requested_id":null,"requested_status":null},"metadata":{"rendered_id":null,"requested_id":null,"requested_status":null},"sandbox_cape":{"rendered_id":null,"requested_id":null,"requested_status":null},"sandbox_triage":{"rendered_id":null,"requested_id":null,"requested_status":null}}},"status":"OK"}
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Authorization
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '530'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 06 May 2026 16:35:56 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '111'
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
## TL;DR
- Switch sync and async `sample()` clients from `GET /v3/sample/<sha256>` to `POST` with `community` in the JSON body, matching the new artifact-index contract (community is now mandatory).
- Follows the existing `scan` / `submit` / `sandbox` / `bundle` / `report_task` convention: `community` is taken from `self.community`, not exposed as a per-call kwarg.
- Adds the new `llm_report_id` resource id to both sync and async sample methods.
- Adds VCR cassettes (`test_sample`, `test_async_sample`) recorded against the e2e service.

## Requires
- artifact-index commit `9a336fe2` (`feat(views/sample): accept POST and require an explicit community`) deployed to the target environment. Without it, POST requests will 404 and the legacy GET path will not enforce community, so this client change is safe to merge before that deploys but only useful after.

## Notes
- The `Sample._get_endpoint` override is left in place for one cycle while artifact-index still accepts GET; it can be removed once the legacy verb is dropped server-side.
- No version bump in this PR — `polyswarm-cli` is currently consuming this via editable install from a sibling checkout.