### PR TITLE
DN-8130: expose md5 and sha1 on hunt result resources

### DIFF
--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -803,6 +803,8 @@ class LiveHuntResult(core.BaseJsonResource):
         self.instance_id = content['instance_id']
         self.created = core.parse_isoformat(content['created'])
         self.sha256 = content['sha256']
+        self.md5 = content.get('md5')
+        self.sha1 = content.get('sha1')
         self.rule_name = content['rule_name']
         self.tags = content['tags']
         self.polyscore = content['polyscore']
@@ -848,6 +850,8 @@ class HistoricalHuntResult(core.BaseJsonResource):
         self.historicalscan_id = content['historicalscan_id']
         self.instance_id = content['instance_id']
         self.sha256 = content['sha256']
+        self.md5 = content.get('md5')
+        self.sha1 = content.get('sha1')
         self.created = core.parse_isoformat(content['created'])
         self.rule_name = content['rule_name']
         self.tags = content['tags']


### PR DESCRIPTION
## TL;DR

- `LiveHuntResult` and `HistoricalHuntResult` now read `md5` and `sha1` off the artifact-index response, alongside the existing `sha256`.
- Uses `.get()` so older responses (or rows pre-dating the artifact-index backend migration with null md5/sha1) deserialize cleanly to `None`.

Ticket: [DN-8130](https://polyswarm.atlassian.net/browse/DN-8130). Pairs with artifact-index [polyswarm/artifact-index#1865](https://github.com/polyswarm/artifact-index/pull/1865).

## Requires

- artifact-index PR #1865 — server-side change that surfaces md5/sha1 in `/v3/hunt/live` and `/v3/hunt/historical/results` responses. This API change is forward-compatible: against older artifact-index servers, the fields stay `None`.

## Test plan

- [ ] Existing `test_live` / `test_historical_results` cassettes still play back cleanly (55/55 tests pass locally)
- [ ] Against an artifact-index deployment carrying the matching PR, `api.live_result(id).md5` / `.sha1` return the expected hex strings
- [ ] Against an older artifact-index deployment, `.md5` / `.sha1` are `None` and no AttributeError

[DN-8130]: https://polyswarm.atlassian.net/browse/DN-8130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ