### PR TITLE
chore: bump version 3.20.0 → 3.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyswarm_api"
-version = "3.20.0"
+version = "3.21.0"
 description = "Client library to simplify interacting with the PolySwarm consumer API"
 readme = "README.md"
 requires-python = ">=3.10,<4"
@@ -49,7 +49,7 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.bumpversion]
-current_version = "3.20.0"
+current_version = "3.21.0"
 commit = true
 tag = false
 sign_tags = true

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '3.20.0'
+__version__ = '3.21.0'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api


### PR DESCRIPTION
## TL;DR
- Bump `polyswarm_api` minor version: 3.20.0 → 3.21.0