### PR TITLE
Version 3.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyswarm_api"
-version = "3.20.0"
+version = "3.21.0"
 description = "Client library to simplify interacting with the PolySwarm consumer API"
 readme = "README.md"
 requires-python = ">=3.10,<4"
@@ -49,7 +49,7 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.bumpversion]
-current_version = "3.20.0"
+current_version = "3.21.0"
 commit = true
 tag = false
 sign_tags = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 dependencies = [
   "requests>=2.31",
   "python-dateutil>=2.9",
+  "jmespath>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '3.20.0'
+__version__ = '3.21.0'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api

--- a/src/polyswarm_api/core.py
+++ b/src/polyswarm_api/core.py
@@ -258,6 +258,27 @@ class BaseJsonResource(BaseResource):
             raise TypeError(f'Resource {type(self).__name__} does not have an id and can not be cast to int')
         return int(id_)
 
+    def jmespath(self, expr):
+        """Apply a JMESPath expression to this resource's underlying JSON.
+
+        Lets callers pull fields out of any API response without manual dotted-path
+        navigation or piping ``--fmt json`` CLI output through ``jq``. Uses JMESPath
+        syntax — see https://jmespath.org for the full grammar (no leading dot,
+        ``[*]`` projections, ``[?expr]`` filters, function calls, etc.).
+
+        Returns ``None`` when the expression resolves nothing in the document.
+
+        Example::
+
+            instance = api.lookup(scan_id)
+            polyscore = instance.jmespath("scan.latest_scan.polyscore")
+            mal_engines = instance.jmespath(
+                "scan.latest_scan.assertions[?verdict=='malicious'].engine.name"
+            )
+        """
+        import jmespath as _jmespath
+        return _jmespath.search(expr, self.json)
+
     def _get(self, path, default=None, content=None):
         """
         Helper for rendering attributes of child objects in the json that might be None.

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -803,6 +803,8 @@ class LiveHuntResult(core.BaseJsonResource):
         self.instance_id = content['instance_id']
         self.created = core.parse_isoformat(content['created'])
         self.sha256 = content['sha256']
+        self.md5 = content.get('md5')
+        self.sha1 = content.get('sha1')
         self.rule_name = content['rule_name']
         self.tags = content['tags']
         self.polyscore = content['polyscore']
@@ -848,6 +850,8 @@ class HistoricalHuntResult(core.BaseJsonResource):
         self.historicalscan_id = content['historicalscan_id']
         self.instance_id = content['instance_id']
         self.sha256 = content['sha256']
+        self.md5 = content.get('md5')
+        self.sha1 = content.get('sha1')
         self.created = core.parse_isoformat(content['created'])
         self.rule_name = content['rule_name']
         self.tags = content['tags']

--- a/test/jmespath_test.py
+++ b/test/jmespath_test.py
@@ -1,0 +1,72 @@
+"""Tests for BaseJsonResource.jmespath().
+
+Exercises the helper against synthetic content — the helper just delegates to
+jmespath.search(expr, self.json), so we don't need a real API response.
+"""
+
+from polyswarm_api.core import BaseJsonResource
+from polyswarm_api.resources import MetadataMapping
+
+
+def _resource(content):
+    return BaseJsonResource(content)
+
+
+def test_jmespath_simple_field():
+    r = _resource({"polyscore": 0.92})
+    assert r.jmespath("polyscore") == 0.92
+
+
+def test_jmespath_nested_dotted_path():
+    r = _resource({"scan": {"latest_scan": {"polyscore": 0.92}}})
+    assert r.jmespath("scan.latest_scan.polyscore") == 0.92
+
+
+def test_jmespath_returns_none_for_missing_path():
+    r = _resource({"a": {"b": 1}})
+    assert r.jmespath("a.c.d") is None
+    assert r.jmespath("nope") is None
+
+
+def test_jmespath_array_projection():
+    r = _resource({
+        "engines": [
+            {"name": "a"},
+            {"name": "b"},
+            {"name": "c"},
+        ],
+    })
+    assert r.jmespath("engines[*].name") == ["a", "b", "c"]
+
+
+def test_jmespath_filter_expression():
+    r = _resource({
+        "engines": [
+            {"name": "a", "verdict": "malicious"},
+            {"name": "b", "verdict": "benign"},
+            {"name": "c", "verdict": "malicious"},
+        ],
+    })
+    assert r.jmespath("engines[?verdict=='malicious'].name") == ["a", "c"]
+
+
+def test_jmespath_keys_function():
+    r = _resource({"foo": 1, "bar": 2, "baz": 3})
+    assert sorted(r.jmespath("keys(@)")) == ["bar", "baz", "foo"]
+
+
+def test_jmespath_length_function():
+    r = _resource({"engines": [1, 2, 3, 4, 5]})
+    assert r.jmespath("length(engines)") == 5
+
+
+def test_jmespath_works_on_subclass():
+    """Any BaseJsonResource subclass inherits .jmespath() automatically."""
+    m = MetadataMapping({"artifact": {"sha256": {"description": "hash"}}})
+    assert m.jmespath("artifact.sha256.description") == "hash"
+
+
+def test_jmespath_pipe():
+    """JMESPath pipe expressions work — | composes a sub-query on the previous result."""
+    r = _resource({"engines": [{"name": "z"}, {"name": "a"}, {"name": "m"}]})
+    assert r.jmespath("engines[*].name | sort(@)") == ["a", "m", "z"]


### PR DESCRIPTION
### New Features

- **Added `jmespath()` helper on `BaseJsonResource`** — Resources now expose a `jmespath(expr)` method that runs a JMESPath expression against the underlying JSON, removing the need for manual dotted-path traversal or piping `--fmt json` output through `jq`.
- **Exposed `md5` and `sha1` on hunt result resources** — `LiveHuntResult` and `HistoricalHuntResult` now surface `md5` and `sha1` (when present in the API response) alongside `sha256`.

### Version Bump

- Bumped version from **3.20.0** → **3.21.0** (`pyproject.toml`, `__init__.py`).