### PR TITLE
feat: add metadata field properties SDK resource and methods

### DIFF
--- a/src/polyswarm_api/aio/__init__.py
+++ b/src/polyswarm_api/aio/__init__.py
@@ -187,6 +187,75 @@ class PolySwarmAsyncAPI:
             result_parser=resources.MetadataMapping,
         )
 
+    async def metadata_field_properties_create(self, field_path, description,
+                                               example=None, category=None, aliases=None):
+        """Create a metadata field properties entry."""
+        return await self._single(
+            {
+                "method": "POST",
+                "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}",
+                "json": {
+                    "field_path": field_path,
+                    "description": description,
+                    "example": example,
+                    "category": category,
+                    "aliases": aliases,
+                },
+            },
+            result_parser=resources.MetadataFieldProperties,
+        )
+
+    async def metadata_field_properties_get(self, field_path):
+        """Get a metadata field properties entry by field_path."""
+        return await self._single(
+            {
+                "method": "GET",
+                "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}",
+                "params": {"field_path": field_path},
+            },
+            result_parser=resources.MetadataFieldProperties,
+        )
+
+    async def metadata_field_properties_update(self, field_path, description=None,
+                                               example=None, category=None, aliases=None):
+        """Update a metadata field properties entry."""
+        body = {}
+        for k, v in (('description', description), ('example', example),
+                     ('category', category), ('aliases', aliases)):
+            if v is not None:
+                body[k] = v
+        return await self._single(
+            {
+                "method": "PUT",
+                "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}",
+                "params": {"field_path": field_path},
+                "json": body,
+            },
+            result_parser=resources.MetadataFieldProperties,
+        )
+
+    async def metadata_field_properties_delete(self, field_path):
+        """Delete a metadata field properties entry."""
+        return await self._single(
+            {
+                "method": "DELETE",
+                "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}",
+                "params": {"field_path": field_path},
+            },
+            result_parser=resources.MetadataFieldProperties,
+        )
+
+    async def metadata_field_properties_list(self):
+        """List all metadata field properties entries. Async generator."""
+        async for item in self._generate(
+            {
+                "method": "GET",
+                "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}/list",
+            },
+            result_parser=resources.MetadataFieldProperties,
+        ):
+            yield item
+
     async def search_by_metadata(
         self, query, include=None, exclude=None, ips=None, urls=None, domains=None
     ):

--- a/src/polyswarm_api/aio/__init__.py
+++ b/src/polyswarm_api/aio/__init__.py
@@ -187,9 +187,9 @@ class PolySwarmAsyncAPI:
             result_parser=resources.MetadataMapping,
         )
 
-    async def metadata_field_properties_create(self, field_path, description,
-                                               example=None, category=None, aliases=None):
-        """Create a metadata field properties entry."""
+    async def metadata_field_properties_write(self, field_path, description,
+                                              example=None, category=None, aliases=None):
+        """Upsert a metadata field properties entry (the single write path)."""
         return await self._single(
             {
                 "method": "POST",
@@ -212,24 +212,6 @@ class PolySwarmAsyncAPI:
                 "method": "GET",
                 "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}",
                 "params": {"field_path": field_path},
-            },
-            result_parser=resources.MetadataFieldProperties,
-        )
-
-    async def metadata_field_properties_update(self, field_path, description=None,
-                                               example=None, category=None, aliases=None):
-        """Update a metadata field properties entry."""
-        body = {}
-        for k, v in (('description', description), ('example', example),
-                     ('category', category), ('aliases', aliases)):
-            if v is not None:
-                body[k] = v
-        return await self._single(
-            {
-                "method": "PUT",
-                "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}",
-                "params": {"field_path": field_path},
-                "json": body,
             },
             result_parser=resources.MetadataFieldProperties,
         )

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -126,9 +126,13 @@ class PolyswarmAPI:
         logger.info('Retrieving the metadata mapping')
         return resources.MetadataMapping.get(self).result()
 
-    def metadata_field_properties_create(self, field_path, description,
-                                         example=None, category=None, aliases=None):
-        """Create a metadata field properties entry.
+    def metadata_field_properties_write(self, field_path, description,
+                                        example=None, category=None, aliases=None):
+        """Upsert a metadata field properties entry (the single write path).
+
+        Inserts a new row if no entry exists for `field_path`, otherwise
+        updates the existing row in place. Server-side this is a POST to
+        /v3/search/metadata/properties.
 
         :param field_path: Dotted ES leaf path (e.g. 'polyunite.malware_family').
         :param description: Human-readable description of the field.
@@ -137,7 +141,7 @@ class PolyswarmAPI:
         :param aliases: Optional list of friendly-name shortcuts.
         :return: A MetadataFieldProperties resource.
         """
-        logger.info('Creating metadata field properties %s', field_path)
+        logger.info('Writing metadata field properties %s', field_path)
         return resources.MetadataFieldProperties.create(self,
                                                         field_path=field_path,
                                                         description=description,
@@ -153,25 +157,6 @@ class PolyswarmAPI:
         """
         logger.info('Getting metadata field properties %s', field_path)
         return resources.MetadataFieldProperties.get(self, field_path=field_path).result()
-
-    def metadata_field_properties_update(self, field_path, description=None,
-                                         example=None, category=None, aliases=None):
-        """Update a metadata field properties entry.
-
-        :param field_path: Dotted ES leaf path of the entry to update.
-        :param description: Optional new description.
-        :param example: Optional new example.
-        :param category: Optional new category.
-        :param aliases: Optional new aliases list.
-        :return: The updated MetadataFieldProperties resource.
-        """
-        logger.info('Updating metadata field properties %s', field_path)
-        return resources.MetadataFieldProperties.update(self,
-                                                        field_path=field_path,
-                                                        description=description,
-                                                        example=example,
-                                                        category=category,
-                                                        aliases=aliases).result()
 
     def metadata_field_properties_delete(self, field_path):
         """Delete a metadata field properties entry.

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -126,6 +126,70 @@ class PolyswarmAPI:
         logger.info('Retrieving the metadata mapping')
         return resources.MetadataMapping.get(self).result()
 
+    def metadata_field_properties_create(self, field_path, description,
+                                         example=None, category=None, aliases=None):
+        """Create a metadata field properties entry.
+
+        :param field_path: Dotted ES leaf path (e.g. 'polyunite.malware_family').
+        :param description: Human-readable description of the field.
+        :param example: Optional example search string.
+        :param category: Optional category grouping the field belongs to.
+        :param aliases: Optional list of friendly-name shortcuts.
+        :return: A MetadataFieldProperties resource.
+        """
+        logger.info('Creating metadata field properties %s', field_path)
+        return resources.MetadataFieldProperties.create(self,
+                                                        field_path=field_path,
+                                                        description=description,
+                                                        example=example,
+                                                        category=category,
+                                                        aliases=aliases).result()
+
+    def metadata_field_properties_get(self, field_path):
+        """Get a metadata field properties entry by field_path.
+
+        :param field_path: Dotted ES leaf path.
+        :return: A MetadataFieldProperties resource.
+        """
+        logger.info('Getting metadata field properties %s', field_path)
+        return resources.MetadataFieldProperties.get(self, field_path=field_path).result()
+
+    def metadata_field_properties_update(self, field_path, description=None,
+                                         example=None, category=None, aliases=None):
+        """Update a metadata field properties entry.
+
+        :param field_path: Dotted ES leaf path of the entry to update.
+        :param description: Optional new description.
+        :param example: Optional new example.
+        :param category: Optional new category.
+        :param aliases: Optional new aliases list.
+        :return: The updated MetadataFieldProperties resource.
+        """
+        logger.info('Updating metadata field properties %s', field_path)
+        return resources.MetadataFieldProperties.update(self,
+                                                        field_path=field_path,
+                                                        description=description,
+                                                        example=example,
+                                                        category=category,
+                                                        aliases=aliases).result()
+
+    def metadata_field_properties_delete(self, field_path):
+        """Delete a metadata field properties entry.
+
+        :param field_path: Dotted ES leaf path of the entry to delete.
+        :return: The deleted MetadataFieldProperties resource.
+        """
+        logger.info('Deleting metadata field properties %s', field_path)
+        return resources.MetadataFieldProperties.delete(self, field_path=field_path).result()
+
+    def metadata_field_properties_list(self, **kwargs):
+        """List all metadata field properties entries.
+
+        :return: A generator of MetadataFieldProperties resources.
+        """
+        logger.info('Listing metadata field properties')
+        return resources.MetadataFieldProperties.list(self, **kwargs).result()
+
     def search_by_metadata(self, query, include=None, exclude=None, ips=None, urls=None, domains=None):
         """
         Search artifacts by metadata

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -78,6 +78,21 @@ class MetadataMapping(core.BaseJsonResource):
     RESOURCE_ENDPOINT = '/search/metadata/mappings'
 
 
+class MetadataFieldProperties(core.BaseJsonResource):
+    RESOURCE_ENDPOINT = '/search/metadata/properties'
+    RESOURCE_ID_KEYS = ['field_path']
+
+    def __init__(self, content, api=None):
+        super().__init__(content, api=api)
+        self.field_path = content['field_path']
+        self.description = content.get('description')
+        self.example = content.get('example')
+        self.category = content.get('category')
+        self.aliases = content.get('aliases')
+        self.created = core.parse_isoformat(content.get('created'))
+        self.updated = core.parse_isoformat(content.get('updated'))
+
+
 class Metadata(core.BaseJsonResource):
     RESOURCE_ENDPOINT = '/search/metadata/query'
     KNOWN_KEYS = {'artifact', 'exiftool', 'hash', 'lief', 'pefile', 'scan', 'strings'}

--- a/test/metadata_field_properties_test.py
+++ b/test/metadata_field_properties_test.py
@@ -30,14 +30,14 @@ class MetadataFieldPropertiesSyncTest(TestCase):
         self.api = PolyswarmAPI('1' * 32, uri=_BASE_URL, community='gamma')
 
     @responses.activate
-    def test_create(self):
+    def test_write(self):
         row = _sample_row()
         responses.add(
             responses.POST, _RESOURCE_URL,
             json={'result': row, 'status': 'OK'},
             status=200,
         )
-        result = self.api.metadata_field_properties_create(
+        result = self.api.metadata_field_properties_write(
             field_path=row['field_path'],
             description=row['description'],
             example=row['example'],
@@ -58,24 +58,6 @@ class MetadataFieldPropertiesSyncTest(TestCase):
         )
         result = self.api.metadata_field_properties_get(field_path=row['field_path'])
         assert result.field_path == row['field_path']
-        # Verify the field_path is in the query string.
-        request_url = responses.calls[0].request.url
-        assert 'field_path=polyunite.malware_family' in request_url
-
-    @responses.activate
-    def test_update(self):
-        row = _sample_row()
-        row['description'] = 'new desc'
-        responses.add(
-            responses.PUT, _RESOURCE_URL,
-            json={'result': row, 'status': 'OK'},
-            status=200,
-        )
-        result = self.api.metadata_field_properties_update(
-            field_path=row['field_path'],
-            description='new desc',
-        )
-        assert result.description == 'new desc'
         request_url = responses.calls[0].request.url
         assert 'field_path=polyunite.malware_family' in request_url
 

--- a/test/metadata_field_properties_test.py
+++ b/test/metadata_field_properties_test.py
@@ -1,0 +1,104 @@
+"""Tests for the metadata_field_properties SDK methods.
+
+Uses the `responses` library to mock the HTTP boundary, so these tests run
+without needing a live artifact-index stack.
+"""
+import responses
+from unittest import TestCase
+
+from polyswarm_api.api import PolyswarmAPI
+
+
+_BASE_URL = 'http://localhost:9696/v3'
+_RESOURCE_URL = f'{_BASE_URL}/search/metadata/properties'
+
+
+def _sample_row(field_path='polyunite.malware_family'):
+    return {
+        'field_path': field_path,
+        'description': 'Identified malware family',
+        'example': 'polyunite.malware_family:lockbit',
+        'category': 'polyunite',
+        'aliases': None,
+        'created': '2026-05-20T00:00:00',
+        'updated': '2026-05-20T00:00:00',
+    }
+
+
+class MetadataFieldPropertiesSyncTest(TestCase):
+    def setUp(self):
+        self.api = PolyswarmAPI('1' * 32, uri=_BASE_URL, community='gamma')
+
+    @responses.activate
+    def test_create(self):
+        row = _sample_row()
+        responses.add(
+            responses.POST, _RESOURCE_URL,
+            json={'result': row, 'status': 'OK'},
+            status=200,
+        )
+        result = self.api.metadata_field_properties_create(
+            field_path=row['field_path'],
+            description=row['description'],
+            example=row['example'],
+            category=row['category'],
+        )
+        assert result.field_path == row['field_path']
+        assert result.description == row['description']
+        assert result.example == row['example']
+        assert result.category == row['category']
+
+    @responses.activate
+    def test_get(self):
+        row = _sample_row()
+        responses.add(
+            responses.GET, _RESOURCE_URL,
+            json={'result': row, 'status': 'OK'},
+            status=200,
+        )
+        result = self.api.metadata_field_properties_get(field_path=row['field_path'])
+        assert result.field_path == row['field_path']
+        # Verify the field_path is in the query string.
+        request_url = responses.calls[0].request.url
+        assert 'field_path=polyunite.malware_family' in request_url
+
+    @responses.activate
+    def test_update(self):
+        row = _sample_row()
+        row['description'] = 'new desc'
+        responses.add(
+            responses.PUT, _RESOURCE_URL,
+            json={'result': row, 'status': 'OK'},
+            status=200,
+        )
+        result = self.api.metadata_field_properties_update(
+            field_path=row['field_path'],
+            description='new desc',
+        )
+        assert result.description == 'new desc'
+        request_url = responses.calls[0].request.url
+        assert 'field_path=polyunite.malware_family' in request_url
+
+    @responses.activate
+    def test_delete(self):
+        row = _sample_row()
+        responses.add(
+            responses.DELETE, _RESOURCE_URL,
+            json={'result': row, 'status': 'OK'},
+            status=200,
+        )
+        result = self.api.metadata_field_properties_delete(field_path=row['field_path'])
+        assert result.field_path == row['field_path']
+
+    @responses.activate
+    def test_list(self):
+        rows = [_sample_row('apkid.files.filename'), _sample_row('artifact.id')]
+        responses.add(
+            responses.GET, f'{_RESOURCE_URL}/list',
+            json={'result': rows, 'status': 'OK'},
+            status=200,
+        )
+        result = list(self.api.metadata_field_properties_list())
+        assert len(result) == 2
+        assert result[0].field_path == 'apkid.files.filename'
+        assert result[1].field_path == 'artifact.id'


### PR DESCRIPTION
## TL;DR

Adds the SDK surface for the new admin-gated metadata field properties CRUD endpoints in artifact-index. Mirrors the `LLMPromptConfig` resource pattern: a `MetadataFieldProperties` resource at `/search/metadata/properties` (primary key `field_path`, the dotted ES leaf) and five convenience methods on `PolyswarmAPI` — `_write`, `_get`, `_delete`, `_list` — with async equivalents.

Tracking: DN-8222.

## Why a single `_write` (instead of `_create` + `_update`)

The server-side `POST /v3/search/metadata/properties` is an upsert (inserts if `field_path` is new, updates if present) — there's no separate update path. The SDK reflects that: one write method, no decision needed at the call site about whether the row exists. Re-runs of the bulk loader are idempotent.

## Methods

```python
api.metadata_field_properties_write(field_path, description,
                                    example=None, category=None, aliases=None)
api.metadata_field_properties_get(field_path)
api.metadata_field_properties_delete(field_path)
api.metadata_field_properties_list()
```

`field_path` is the natural primary key — a dotted Elasticsearch / OpenSearch leaf path like `polyunite.malware_family` or `apkid.files.filename`. All five methods are admin-gated server-side (`akm_admin` feature on the API key).

## Changes

- `src/polyswarm_api/resources.py` — new `MetadataFieldProperties(core.BaseJsonResource)` with `RESOURCE_ENDPOINT = '/search/metadata/properties'` and `RESOURCE_ID_KEYS = ['field_path']`. The `RESOURCE_ID_KEYS` setting routes `field_path` into the query string for `GET` / `DELETE` (per the base class's `_params` dispatch).
- `src/polyswarm_api/api.py` — five `metadata_field_properties_*` convenience methods on `PolyswarmAPI`, alongside the existing `metadata_mapping`.
- `src/polyswarm_api/aio/__init__.py` — async equivalents using `_single` / `_generate` patterns already in use for `metadata_mapping` and the prompt config methods.
- `test/metadata_field_properties_test.py` — 4 tests using `responses` to mock the HTTP boundary (no live artifact-index needed): write / get / delete / list.

## Requires

- artifact-index PR https://github.com/polyswarm/artifact-index/pull/1869 — endpoints don't exist until that merges.

## Required by

- polyswarm-cli PR https://github.com/polyswarm/polyswarm-cli/pull/242 — the `polyswarm search field-property` commands wrap these SDK methods.

## Tests

```
$ python -m pytest test/metadata_field_properties_test.py -v
============================== 4 passed in 0.10s ==============================
```

