### PR TITLE
Metadata field properties SDK — develop-targeted resubmit + gitflow docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md — polyswarm-api
+
+Orientation document for AI agents and humans new to the repo. Update it when major workflow decisions land.
+
+## Gitflow — **read this before opening a PR**
+
+This repo follows a strict `feature → develop → master` flow:
+
+```
+feature/*  ─┐
+            └─► develop  ─►  master
+```
+
+**Rules:**
+
+- **Feature PRs target `develop`**, never `master`. Branch off `develop`, push, open a PR with `develop` as the base. CI runs on the PR. Reviewers merge to `develop`.
+- **`develop → master` PRs are how `master` advances.** They're opened by a maintainer when a release-worthy batch of work is on `develop`. Most contributors never open one of these.
+- **Direct PRs to `master`** are wrong. If you opened one, close it, branch off `develop` instead, and re-open against `develop`.
+- **PyPI release happens automatically** when `pyproject.toml`'s `version` changes on `master`. Don't bump the version inside a feature PR unless the maintainer specifically asks — version bumps belong to the `develop → master` step.
+
+**Why this matters:** `master` is the published surface of the SDK. PyPI consumers see whatever shows up there. Skipping `develop` skips the integration soak that protects against accidentally shipping a half-baked change.
+
+### Checking the base before pushing
+
+Before pushing a feature branch, sanity-check what `gh pr create` will target:
+
+```bash
+gh pr create --base develop --head <your-branch> --title "<…>" --body "<…>"
+```
+
+If you ever omit `--base`, the gh CLI defaults to the repo's default branch — which on this repo is `develop`, but it's worth being explicit.
+
+### Past incident
+
+PR #295 was merged directly to `master` and had to be reverted (#296) and re-opened against `develop`. The version file wasn't touched, so no PyPI release fired — but the rollback was still disruptive. Don't repeat it.
+
+## Layout
+
+- `src/polyswarm_api/` — the synchronous `PolyswarmAPI` client (`api.py`), the `core.BaseJsonResource` machinery (`core.py`), and the per-domain resource classes (`resources.py`).
+- `src/polyswarm_api/aio/` — async equivalent.
+- `test/` — pytest suite using `responses` to mock the HTTP boundary; no live polyswarm stack required for the unit tests.
+
+## When adding a new resource
+
+Mirror the existing patterns (`LLMPromptConfig`, `MetadataFieldProperties`, `YaraRuleset`):
+
+1. `class FooBar(core.BaseJsonResource): RESOURCE_ENDPOINT = '/…'`. If the resource's identifier isn't `id`, set `RESOURCE_ID_KEYS = ['your_key']` so the base class routes it into the query string for `GET`/`DELETE`/`PUT`.
+2. Add convenience methods on `PolyswarmAPI` in `api.py` (and the async equivalent in `aio/__init__.py`) — these are what CLI commands and downstream consumers call.
+3. Test with `responses.activate` mocking the HTTP boundary — no need for a live stack or VCR cassettes for unit tests.
+
+## Companion repos
+
+- `polyswarm-cli` — wraps these methods in click commands. SDK changes that need a CLI surface usually ship as a pair (`polyswarm-api` PR + `polyswarm-cli` PR with the SDK PR linked under `## Requires`).
+- `artifact-index` — the server-side API the SDK talks to. New endpoints land there first; the SDK PR comes after.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/polyswarm_api/aio/__init__.py
+++ b/src/polyswarm_api/aio/__init__.py
@@ -187,6 +187,75 @@ class PolySwarmAsyncAPI:
             result_parser=resources.MetadataMapping,
         )
 
+    async def metadata_field_properties_create(self, field_path, description,
+                                               example=None, category=None, aliases=None):
+        """Create a metadata field properties entry."""
+        return await self._single(
+            {
+                "method": "POST",
+                "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}",
+                "json": {
+                    "field_path": field_path,
+                    "description": description,
+                    "example": example,
+                    "category": category,
+                    "aliases": aliases,
+                },
+            },
+            result_parser=resources.MetadataFieldProperties,
+        )
+
+    async def metadata_field_properties_get(self, field_path):
+        """Get a metadata field properties entry by field_path."""
+        return await self._single(
+            {
+                "method": "GET",
+                "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}",
+                "params": {"field_path": field_path},
+            },
+            result_parser=resources.MetadataFieldProperties,
+        )
+
+    async def metadata_field_properties_update(self, field_path, description=None,
+                                               example=None, category=None, aliases=None):
+        """Update a metadata field properties entry."""
+        body = {}
+        for k, v in (('description', description), ('example', example),
+                     ('category', category), ('aliases', aliases)):
+            if v is not None:
+                body[k] = v
+        return await self._single(
+            {
+                "method": "PUT",
+                "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}",
+                "params": {"field_path": field_path},
+                "json": body,
+            },
+            result_parser=resources.MetadataFieldProperties,
+        )
+
+    async def metadata_field_properties_delete(self, field_path):
+        """Delete a metadata field properties entry."""
+        return await self._single(
+            {
+                "method": "DELETE",
+                "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}",
+                "params": {"field_path": field_path},
+            },
+            result_parser=resources.MetadataFieldProperties,
+        )
+
+    async def metadata_field_properties_list(self):
+        """List all metadata field properties entries. Async generator."""
+        async for item in self._generate(
+            {
+                "method": "GET",
+                "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}/list",
+            },
+            result_parser=resources.MetadataFieldProperties,
+        ):
+            yield item
+
     async def search_by_metadata(
         self, query, include=None, exclude=None, ips=None, urls=None, domains=None
     ):

--- a/src/polyswarm_api/aio/__init__.py
+++ b/src/polyswarm_api/aio/__init__.py
@@ -187,9 +187,9 @@ class PolySwarmAsyncAPI:
             result_parser=resources.MetadataMapping,
         )
 
-    async def metadata_field_properties_create(self, field_path, description,
-                                               example=None, category=None, aliases=None):
-        """Create a metadata field properties entry."""
+    async def metadata_field_properties_write(self, field_path, description,
+                                              example=None, category=None, aliases=None):
+        """Upsert a metadata field properties entry (the single write path)."""
         return await self._single(
             {
                 "method": "POST",
@@ -212,24 +212,6 @@ class PolySwarmAsyncAPI:
                 "method": "GET",
                 "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}",
                 "params": {"field_path": field_path},
-            },
-            result_parser=resources.MetadataFieldProperties,
-        )
-
-    async def metadata_field_properties_update(self, field_path, description=None,
-                                               example=None, category=None, aliases=None):
-        """Update a metadata field properties entry."""
-        body = {}
-        for k, v in (('description', description), ('example', example),
-                     ('category', category), ('aliases', aliases)):
-            if v is not None:
-                body[k] = v
-        return await self._single(
-            {
-                "method": "PUT",
-                "url": f"{self.uri}{resources.MetadataFieldProperties.RESOURCE_ENDPOINT}",
-                "params": {"field_path": field_path},
-                "json": body,
             },
             result_parser=resources.MetadataFieldProperties,
         )

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -126,9 +126,13 @@ class PolyswarmAPI:
         logger.info('Retrieving the metadata mapping')
         return resources.MetadataMapping.get(self).result()
 
-    def metadata_field_properties_create(self, field_path, description,
-                                         example=None, category=None, aliases=None):
-        """Create a metadata field properties entry.
+    def metadata_field_properties_write(self, field_path, description,
+                                        example=None, category=None, aliases=None):
+        """Upsert a metadata field properties entry (the single write path).
+
+        Inserts a new row if no entry exists for `field_path`, otherwise
+        updates the existing row in place. Server-side this is a POST to
+        /v3/search/metadata/properties.
 
         :param field_path: Dotted ES leaf path (e.g. 'polyunite.malware_family').
         :param description: Human-readable description of the field.
@@ -137,7 +141,7 @@ class PolyswarmAPI:
         :param aliases: Optional list of friendly-name shortcuts.
         :return: A MetadataFieldProperties resource.
         """
-        logger.info('Creating metadata field properties %s', field_path)
+        logger.info('Writing metadata field properties %s', field_path)
         return resources.MetadataFieldProperties.create(self,
                                                         field_path=field_path,
                                                         description=description,
@@ -153,25 +157,6 @@ class PolyswarmAPI:
         """
         logger.info('Getting metadata field properties %s', field_path)
         return resources.MetadataFieldProperties.get(self, field_path=field_path).result()
-
-    def metadata_field_properties_update(self, field_path, description=None,
-                                         example=None, category=None, aliases=None):
-        """Update a metadata field properties entry.
-
-        :param field_path: Dotted ES leaf path of the entry to update.
-        :param description: Optional new description.
-        :param example: Optional new example.
-        :param category: Optional new category.
-        :param aliases: Optional new aliases list.
-        :return: The updated MetadataFieldProperties resource.
-        """
-        logger.info('Updating metadata field properties %s', field_path)
-        return resources.MetadataFieldProperties.update(self,
-                                                        field_path=field_path,
-                                                        description=description,
-                                                        example=example,
-                                                        category=category,
-                                                        aliases=aliases).result()
 
     def metadata_field_properties_delete(self, field_path):
         """Delete a metadata field properties entry.

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -126,6 +126,70 @@ class PolyswarmAPI:
         logger.info('Retrieving the metadata mapping')
         return resources.MetadataMapping.get(self).result()
 
+    def metadata_field_properties_create(self, field_path, description,
+                                         example=None, category=None, aliases=None):
+        """Create a metadata field properties entry.
+
+        :param field_path: Dotted ES leaf path (e.g. 'polyunite.malware_family').
+        :param description: Human-readable description of the field.
+        :param example: Optional example search string.
+        :param category: Optional category grouping the field belongs to.
+        :param aliases: Optional list of friendly-name shortcuts.
+        :return: A MetadataFieldProperties resource.
+        """
+        logger.info('Creating metadata field properties %s', field_path)
+        return resources.MetadataFieldProperties.create(self,
+                                                        field_path=field_path,
+                                                        description=description,
+                                                        example=example,
+                                                        category=category,
+                                                        aliases=aliases).result()
+
+    def metadata_field_properties_get(self, field_path):
+        """Get a metadata field properties entry by field_path.
+
+        :param field_path: Dotted ES leaf path.
+        :return: A MetadataFieldProperties resource.
+        """
+        logger.info('Getting metadata field properties %s', field_path)
+        return resources.MetadataFieldProperties.get(self, field_path=field_path).result()
+
+    def metadata_field_properties_update(self, field_path, description=None,
+                                         example=None, category=None, aliases=None):
+        """Update a metadata field properties entry.
+
+        :param field_path: Dotted ES leaf path of the entry to update.
+        :param description: Optional new description.
+        :param example: Optional new example.
+        :param category: Optional new category.
+        :param aliases: Optional new aliases list.
+        :return: The updated MetadataFieldProperties resource.
+        """
+        logger.info('Updating metadata field properties %s', field_path)
+        return resources.MetadataFieldProperties.update(self,
+                                                        field_path=field_path,
+                                                        description=description,
+                                                        example=example,
+                                                        category=category,
+                                                        aliases=aliases).result()
+
+    def metadata_field_properties_delete(self, field_path):
+        """Delete a metadata field properties entry.
+
+        :param field_path: Dotted ES leaf path of the entry to delete.
+        :return: The deleted MetadataFieldProperties resource.
+        """
+        logger.info('Deleting metadata field properties %s', field_path)
+        return resources.MetadataFieldProperties.delete(self, field_path=field_path).result()
+
+    def metadata_field_properties_list(self, **kwargs):
+        """List all metadata field properties entries.
+
+        :return: A generator of MetadataFieldProperties resources.
+        """
+        logger.info('Listing metadata field properties')
+        return resources.MetadataFieldProperties.list(self, **kwargs).result()
+
     def search_by_metadata(self, query, include=None, exclude=None, ips=None, urls=None, domains=None):
         """
         Search artifacts by metadata

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -78,6 +78,21 @@ class MetadataMapping(core.BaseJsonResource):
     RESOURCE_ENDPOINT = '/search/metadata/mappings'
 
 
+class MetadataFieldProperties(core.BaseJsonResource):
+    RESOURCE_ENDPOINT = '/search/metadata/properties'
+    RESOURCE_ID_KEYS = ['field_path']
+
+    def __init__(self, content, api=None):
+        super().__init__(content, api=api)
+        self.field_path = content['field_path']
+        self.description = content.get('description')
+        self.example = content.get('example')
+        self.category = content.get('category')
+        self.aliases = content.get('aliases')
+        self.created = core.parse_isoformat(content.get('created'))
+        self.updated = core.parse_isoformat(content.get('updated'))
+
+
 class Metadata(core.BaseJsonResource):
     RESOURCE_ENDPOINT = '/search/metadata/query'
     KNOWN_KEYS = {'artifact', 'exiftool', 'hash', 'lief', 'pefile', 'scan', 'strings'}

--- a/test/metadata_field_properties_test.py
+++ b/test/metadata_field_properties_test.py
@@ -30,14 +30,14 @@ class MetadataFieldPropertiesSyncTest(TestCase):
         self.api = PolyswarmAPI('1' * 32, uri=_BASE_URL, community='gamma')
 
     @responses.activate
-    def test_create(self):
+    def test_write(self):
         row = _sample_row()
         responses.add(
             responses.POST, _RESOURCE_URL,
             json={'result': row, 'status': 'OK'},
             status=200,
         )
-        result = self.api.metadata_field_properties_create(
+        result = self.api.metadata_field_properties_write(
             field_path=row['field_path'],
             description=row['description'],
             example=row['example'],
@@ -58,24 +58,6 @@ class MetadataFieldPropertiesSyncTest(TestCase):
         )
         result = self.api.metadata_field_properties_get(field_path=row['field_path'])
         assert result.field_path == row['field_path']
-        # Verify the field_path is in the query string.
-        request_url = responses.calls[0].request.url
-        assert 'field_path=polyunite.malware_family' in request_url
-
-    @responses.activate
-    def test_update(self):
-        row = _sample_row()
-        row['description'] = 'new desc'
-        responses.add(
-            responses.PUT, _RESOURCE_URL,
-            json={'result': row, 'status': 'OK'},
-            status=200,
-        )
-        result = self.api.metadata_field_properties_update(
-            field_path=row['field_path'],
-            description='new desc',
-        )
-        assert result.description == 'new desc'
         request_url = responses.calls[0].request.url
         assert 'field_path=polyunite.malware_family' in request_url
 

--- a/test/metadata_field_properties_test.py
+++ b/test/metadata_field_properties_test.py
@@ -1,0 +1,104 @@
+"""Tests for the metadata_field_properties SDK methods.
+
+Uses the `responses` library to mock the HTTP boundary, so these tests run
+without needing a live artifact-index stack.
+"""
+import responses
+from unittest import TestCase
+
+from polyswarm_api.api import PolyswarmAPI
+
+
+_BASE_URL = 'http://localhost:9696/v3'
+_RESOURCE_URL = f'{_BASE_URL}/search/metadata/properties'
+
+
+def _sample_row(field_path='polyunite.malware_family'):
+    return {
+        'field_path': field_path,
+        'description': 'Identified malware family',
+        'example': 'polyunite.malware_family:lockbit',
+        'category': 'polyunite',
+        'aliases': None,
+        'created': '2026-05-20T00:00:00',
+        'updated': '2026-05-20T00:00:00',
+    }
+
+
+class MetadataFieldPropertiesSyncTest(TestCase):
+    def setUp(self):
+        self.api = PolyswarmAPI('1' * 32, uri=_BASE_URL, community='gamma')
+
+    @responses.activate
+    def test_create(self):
+        row = _sample_row()
+        responses.add(
+            responses.POST, _RESOURCE_URL,
+            json={'result': row, 'status': 'OK'},
+            status=200,
+        )
+        result = self.api.metadata_field_properties_create(
+            field_path=row['field_path'],
+            description=row['description'],
+            example=row['example'],
+            category=row['category'],
+        )
+        assert result.field_path == row['field_path']
+        assert result.description == row['description']
+        assert result.example == row['example']
+        assert result.category == row['category']
+
+    @responses.activate
+    def test_get(self):
+        row = _sample_row()
+        responses.add(
+            responses.GET, _RESOURCE_URL,
+            json={'result': row, 'status': 'OK'},
+            status=200,
+        )
+        result = self.api.metadata_field_properties_get(field_path=row['field_path'])
+        assert result.field_path == row['field_path']
+        # Verify the field_path is in the query string.
+        request_url = responses.calls[0].request.url
+        assert 'field_path=polyunite.malware_family' in request_url
+
+    @responses.activate
+    def test_update(self):
+        row = _sample_row()
+        row['description'] = 'new desc'
+        responses.add(
+            responses.PUT, _RESOURCE_URL,
+            json={'result': row, 'status': 'OK'},
+            status=200,
+        )
+        result = self.api.metadata_field_properties_update(
+            field_path=row['field_path'],
+            description='new desc',
+        )
+        assert result.description == 'new desc'
+        request_url = responses.calls[0].request.url
+        assert 'field_path=polyunite.malware_family' in request_url
+
+    @responses.activate
+    def test_delete(self):
+        row = _sample_row()
+        responses.add(
+            responses.DELETE, _RESOURCE_URL,
+            json={'result': row, 'status': 'OK'},
+            status=200,
+        )
+        result = self.api.metadata_field_properties_delete(field_path=row['field_path'])
+        assert result.field_path == row['field_path']
+
+    @responses.activate
+    def test_list(self):
+        rows = [_sample_row('apkid.files.filename'), _sample_row('artifact.id')]
+        responses.add(
+            responses.GET, f'{_RESOURCE_URL}/list',
+            json={'result': rows, 'status': 'OK'},
+            status=200,
+        )
+        result = list(self.api.metadata_field_properties_list())
+        assert len(result) == 2
+        assert result[0].field_path == 'apkid.files.filename'
+        assert result[1].field_path == 'artifact.id'


### PR DESCRIPTION
## TL;DR

Re-opening the metadata field properties SDK work against `develop` (was originally #295 to `master`, which has been reverted in #296 — that PR bypassed this repo's `feature → develop → master` gitflow).

Same SDK surface as the original PR — sync + async `metadata_field_properties_*` methods backing the admin-gated CRUD endpoints in artifact-index — plus a new `AGENTS.md` (with a `CLAUDE.md` symlink) documenting the gitflow so this kind of mistake doesn't recur.

Tracking: DN-8222.

## Methods

```python
api.metadata_field_properties_write(field_path, description,
                                    example=None, category=None, aliases=None)
api.metadata_field_properties_get(field_path)
api.metadata_field_properties_delete(field_path)
api.metadata_field_properties_list()
```

- `field_path` is the natural primary key (dotted ES/OS leaf like `polyunite.malware_family`).
- `write` is an upsert — inserts if new, updates if present. The server has no separate update path, so neither does the SDK.
- All methods are admin-gated server-side (`akm_admin` feature).

## Changes

- `src/polyswarm_api/resources.py` — new `MetadataFieldProperties(core.BaseJsonResource)` with `RESOURCE_ENDPOINT = '/search/metadata/properties'` and `RESOURCE_ID_KEYS = ['field_path']`.
- `src/polyswarm_api/api.py` — four `metadata_field_properties_*` convenience methods on `PolyswarmAPI`.
- `src/polyswarm_api/aio/__init__.py` — async equivalents.
- `test/metadata_field_properties_test.py` — 4 tests using `responses` to mock the HTTP boundary (no live artifact-index needed).
- **`AGENTS.md` + `CLAUDE.md`** — new orientation doc documenting the `feature → develop → master` flow so the #295 mistake doesn't recur.

## Tests

```
$ python -m pytest test/metadata_field_properties_test.py -v
============================== 4 passed in 0.10s ==============================
```

## Requires

- artifact-index PR https://github.com/polyswarm/artifact-index/pull/1869 — endpoints don't exist until that merges.

## Required by

- polyswarm-cli PR (forthcoming, will be opened against polyswarm-cli's `develop` for the same gitflow reason).

## Note on the original PR / rollback

- **#295** — original PR, merged directly to `master`. Mistake. No PyPI release fired (version not bumped).
- **#296** — rollback PR, reverts #295 from `master`.
- **This PR** — same SDK diff plus `AGENTS.md`, targeting `develop` as it should have from the start.
