### PR TITLE
ci: add automated Claude code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,79 @@
+name: Claude Code Review
+
+# Auto-review every PR on open + each subsequent push.
+# To pause without removing the file: set `if: false` on the job.
+#
+# Requires repo (or org) secret ANTHROPIC_API_KEY — pay-as-you-go via
+# Anthropic Console, separate from any individual's Claude.com subscription.
+# OAuth-token variant: swap `anthropic_api_key` for `claude_code_oauth_token`.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this PR against the project's CLAUDE.md / AGENTS.md
+            and the `specs/` directory — both are authoritative on
+            conventions, contracts, and intent.
+
+            Focus on real issues, ordered by severity:
+              1. Correctness — bugs, error-handling gaps, request /
+                 response shape mismatches, async/sync boundary
+                 problems (awaiting an async generator, iterating a
+                 coroutine, etc.).
+              2. Spec drift — does the change match specs/*.md? Flag
+                 mismatches or specs that need updates. The shared
+                 sync+async architecture (`PolyswarmAPIBase`) is the
+                 source of truth — new endpoints belong on the base,
+                 not duplicated across `api.py` / `aio/__init__.py`.
+              3. Downstream contract — public method signatures,
+                 response-resource shapes, exception classes, and the
+                 `polyswarm_api.aio.upload.*` module-level callables
+                 are part of the published surface. Breaking changes
+                 need a major version bump.
+              4. Test coverage — does the test exercise the new path?
+                 For endpoint changes, the parametrised
+                 `ClientTestCase` harness should cover both sync and
+                 async paths. New VCR cassettes should follow the
+                 record-on-delete pattern (no hardcoded
+                 `record_mode='none'`).
+              5. Gitflow — feature PRs target `develop`, never
+                 `master`. Version bumps belong to the `develop -->
+                 master` step, not feature PRs.
+
+            Skip:
+              - Style nits that any auto-formatter already enforces.
+              - Suggestions to "consider adding tests" with no specific
+                missing case.
+              - Architectural rewrites for hypothetical future
+                requirements.
+
+            Be terse. Comment only on issues that need action. If the
+            PR is clean, say so in one line and stop.
+
+            Post your review via `gh pr comment`.
+
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## TL;DR

Adds `.github/workflows/claude-code-review.yml`. Runs on every PR open + push; reads `CLAUDE.md` / `AGENTS.md` (and `specs/` if present) for context; posts a review comment via `gh pr comment`.

## Why this is a tiny standalone PR

The action's safety check requires the workflow file to exist (byte-for-byte) on the default branch before it'll run for any PR. A PR that introduces the workflow file itself can never be its own first reviewee — the check refuses to validate a workflow that's only defined on the PR's own branch.

Merging this PR lands the workflow on `develop`. Subsequent PRs against `develop` will then be auto-reviewed.

## Requirements

- Repo or org secret `ANTHROPIC_API_KEY` (already configured at the org level).
- No other configuration changes; nothing else in the repo is touched.

## How to pause without removing it

Set `if: false` on the `claude-review` job.

## What the reviewer focuses on

The prompt asks for ordered severity-first feedback on correctness, spec drift (once `specs/` lands on `develop`), the published downstream contract, test coverage, and gitflow adherence. Style nits are explicitly skipped.

If the PR is clean, the bot says so in one line and stops.