### PR TITLE
ci: pin claude-code-action to commit SHA

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c9d66afb1788e701c57d58842e324dca17fd276e  # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |


### PR DESCRIPTION
## TL;DR

One-line follow-up: pin `anthropics/claude-code-action` from the mutable `@v1` tag to the immutable SHA `c9d66afb1788e701c57d58842e324dca17fd276e` (currently `v1`).

## Why

Pinning to a SHA closes a supply-chain leak vector: a compromised future release tagged `v1.x` would otherwise inherit access to `ANTHROPIC_API_KEY` on its next workflow run. The trailing `# v1` comment keeps the corresponding tag readable for humans and Dependabot.

## Why now (as its own PR)

The action's safety check requires the workflow file on a PR's branch to match `develop`'s copy byte-for-byte. The current open feature PR already has this pin; merging this small PR first makes the two files match, which unblocks the auto-review on every subsequent PR.

No other content change.