### PR TITLE
chore: make claude-code-review workflow prompt generic

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,44 +35,51 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this PR against the project's CLAUDE.md / AGENTS.md
-            and the `specs/` directory — both are authoritative on
-            conventions, contracts, and intent.
+            The authoritative descriptions of how this project works
+            live in the repo itself. Read them first:
 
-            Focus on real issues, ordered by severity:
-              1. Correctness — bugs, error-handling gaps, request /
-                 response shape mismatches, async/sync boundary
-                 problems (awaiting an async generator, iterating a
-                 coroutine, etc.).
-              2. Spec drift — does the change match specs/*.md? Flag
-                 mismatches or specs that need updates. The shared
-                 sync+async architecture (`PolyswarmAPIBase`) is the
-                 source of truth — new endpoints belong on the base,
-                 not duplicated across `api.py` / `aio/__init__.py`.
-              3. Downstream contract — public method signatures,
-                 response-resource shapes, exception classes, and the
-                 `polyswarm_api.aio.upload.*` module-level callables
-                 are part of the published surface. Breaking changes
-                 need a major version bump.
-              4. Test coverage — does the test exercise the new path?
-                 For endpoint changes, the parametrised
-                 `ClientTestCase` harness should cover both sync and
-                 async paths. New VCR cassettes should follow the
-                 record-on-delete pattern (no hardcoded
-                 `record_mode='none'`).
-              5. Gitflow — feature PRs target `develop`, never
-                 `master`. Version bumps belong to the `develop -->
-                 master` step, not feature PRs.
+              - AGENTS.md and CLAUDE.md at the repo root — workspace
+                and project conventions (gitflow, commit hygiene,
+                architectural shape, contributor workflow).
+              - specs/*.md — per-area contracts and invariants. Read
+                the spec for every area the PR touches before
+                reviewing the corresponding code.
+
+            Review the PR against those documents. The project is the
+            ground truth; this prompt only describes the generic
+            review posture.
+
+            Generic priorities:
+              - Correctness. Bugs, error-handling gaps, mismatched
+                request/response shapes, transport boundary problems.
+              - Documented-invariant compliance. Any code that
+                contradicts a spec invariant or an AGENTS.md rule.
+              - Stale documentation. Spec or AGENTS.md sections that
+                no longer match the code (in either direction —
+                missing updates that should accompany this PR, or
+                references that belong in code that have leaked into
+                the docs).
+              - Public-surface compatibility. Changes to documented
+                public symbols (exported classes, method signatures,
+                response shapes, exception classes, module-level
+                monkey-patch sites) need an explicit version-bump
+                decision. The bump policy is in AGENTS.md.
+              - Branch base + version bumps. The gitflow rules in
+                AGENTS.md govern which branch a PR may target and when
+                version bumps are allowed.
+              - Test coverage for new code paths. Flag specific
+                missing cases, not generic "add more tests" notes.
 
             Skip:
-              - Style nits that any auto-formatter already enforces.
-              - Suggestions to "consider adding tests" with no specific
-                missing case.
+              - Style nits any auto-formatter already enforces.
               - Architectural rewrites for hypothetical future
                 requirements.
+              - Generic "consider adding tests" suggestions with no
+                concrete missing case.
 
             Be terse. Comment only on issues that need action. If the
-            PR is clean, say so in one line and stop.
+            PR is clean against the documented conventions, say so in
+            one line and stop.
 
             Post your review via `gh pr comment`.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,47 +35,41 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            The authoritative descriptions of how this project works
-            live in the repo itself. Read them first:
+            Review this PR against the project's CLAUDE.md / AGENTS.md
+            and the `specs/` directory — they are authoritative on
+            conventions, contracts, architecture, and intent. Read the
+            spec for every area the PR touches before reviewing the
+            corresponding code.
 
-              - AGENTS.md and CLAUDE.md at the repo root — workspace
-                and project conventions (gitflow, commit hygiene,
-                architectural shape, contributor workflow).
-              - specs/*.md — per-area contracts and invariants. Read
-                the spec for every area the PR touches before
-                reviewing the corresponding code.
-
-            Review the PR against those documents. The project is the
-            ground truth; this prompt only describes the generic
-            review posture.
-
-            Generic priorities:
-              - Correctness. Bugs, error-handling gaps, mismatched
-                request/response shapes, transport boundary problems.
-              - Documented-invariant compliance. Any code that
-                contradicts a spec invariant or an AGENTS.md rule.
-              - Stale documentation. Spec or AGENTS.md sections that
-                no longer match the code (in either direction —
-                missing updates that should accompany this PR, or
-                references that belong in code that have leaked into
-                the docs).
-              - Public-surface compatibility. Changes to documented
-                public symbols (exported classes, method signatures,
-                response shapes, exception classes, module-level
-                monkey-patch sites) need an explicit version-bump
-                decision. The bump policy is in AGENTS.md.
-              - Branch base + version bumps. The gitflow rules in
-                AGENTS.md govern which branch a PR may target and when
-                version bumps are allowed.
-              - Test coverage for new code paths. Flag specific
-                missing cases, not generic "add more tests" notes.
+            Focus on real issues, ordered by severity:
+              1. Correctness — bugs, error-handling gaps, request /
+                 response shape mismatches, transport-boundary
+                 problems, broken state machines.
+              2. Spec drift — does the change match `AGENTS.md` and
+                 the relevant `specs/*.md`? Flag code that contradicts
+                 a documented invariant, and flag specs that need
+                 updating because the code rightly moved past them.
+                 The architecture rules, file roles, and "where does a
+                 new endpoint go" decisions all live in those docs —
+                 quote them when measuring.
+              3. Downstream contract — changes to the public surface
+                 (exported classes, method signatures, response
+                 shapes, exception classes, monkey-patch sites listed
+                 in the specs) need an explicit version-bump
+                 decision. The bump policy is in AGENTS.md.
+              4. Test coverage — does the test exercise the new path?
+                 Cite specific missing cases. Test conventions (mock
+                 layers, cassette workflow, parametrised harness) are
+                 in `specs/04-testing.md`.
+              5. Gitflow — `AGENTS.md` documents the branch base and
+                 version-bump rules; flag any PR that violates them.
 
             Skip:
               - Style nits any auto-formatter already enforces.
+              - "Consider adding tests" suggestions with no specific
+                missing case.
               - Architectural rewrites for hypothetical future
                 requirements.
-              - Generic "consider adding tests" suggestions with no
-                concrete missing case.
 
             Be terse. Comment only on issues that need action. If the
             PR is clean against the documented conventions, say so in


### PR DESCRIPTION
## TL;DR

The `claude-code-review` workflow prompt currently has project-specific architecture rules baked into the YAML. Push them out into `AGENTS.md` / `CLAUDE.md` / `specs/*.md` — the documents that already describe the project — and shrink the workflow to a generic review posture that points at those docs.

## Why

The `anthropics/claude-code-action@v1` validates the workflow YAML **byte-for-byte against the default branch** before exchanging the OIDC token. Any project specifics inside the workflow turn into a gate against ordinary work:

- A code change that touches a convention also requires updating the workflow's description of that convention.
- That workflow update can't ride along on the same PR — the byte-match guard fails.
- Result: PRs get blocked from the bot review until a separate micro-PR lands the workflow update first.

This bit polyswarm-api PR #298 twice. Once a stale `PolyswarmAPIBase` reference in the prompt; once a stale set of "carve-out" review priorities that no longer match the unasync-codegen architecture.

The fix: keep the workflow YAML stable. Project specifics live in `AGENTS.md` and `specs/*.md`, which evolve naturally with the code.

## What changes

`.github/workflows/claude-code-review.yml` — prompt content. The workflow's `on:` trigger, permissions, action version, allowed-tools list, and OIDC plumbing are unchanged.

Before: 5 numbered priorities with explicit references to `PolyswarmAPIBase`, `aio/__init__.py`, `ClientTestCase`, `polyswarm_api.aio.upload.*`, VCR cassette workflow, develop/master gitflow.

After: a short opening that points the reviewer at `AGENTS.md`, `CLAUDE.md`, and `specs/*.md` as the source of truth, followed by generic review priorities (documented-invariant compliance, public-surface care, gitflow, test coverage) that name no specific file paths or class names.

## Verification

Workflow YAML validity:
- ` `[on:](.github/workflows/claude-code-review.yml#L10)`, [permissions:](.github/workflows/claude-code-review.yml#L17), [action @v1 pin](.github/workflows/claude-code-review.yml#L31), and [claude_args](.github/workflows/claude-code-review.yml#L74) — all unchanged.
- Only the multi-line `prompt:` block is rewritten.

Behaviour after merge:
- The bot's reading list at review time is the current `AGENTS.md` + `specs/`, so any conventions documented there are picked up automatically.
- No future code-change PR will be blocked by stale prompt content.

## Out of scope

This PR doesn't change `AGENTS.md` or any spec — those documents already carry the project specifics the prompt used to duplicate. If a spec needs to be added or rewritten (e.g., a dedicated "Review priorities" section), do it in a separate PR.