### PR TITLE
chore: bump version to 4.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyswarm_api"
-version = "3.21.0"
+version = "4.0.0"
 description = "Client library to simplify interacting with the PolySwarm consumer API"
 readme = "README.md"
 requires-python = ">=3.10,<4"
@@ -55,7 +55,7 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.bumpversion]
-current_version = "3.21.0"
+current_version = "4.0.0"
 commit = true
 tag = false
 sign_tags = true

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '3.21.0'
+__version__ = '4.0.0'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api


### PR DESCRIPTION
Version bump `3.21.0` → `4.0.0` to prep the 4.0 release (done via `bump-my-version`; updates `pyproject.toml` `version`/`current_version` + `src/polyswarm_api/__init__.py` `__version__`).

**Merge this into `develop` first.** It's the prep commit on `develop` for the `develop → master` release PR (per `AGENTS.md` gitflow — the version bump belongs to the develop→master step). Once this is on `develop`, the release PR carries 4.0.0 and merging it to `master` fires the public PyPI release.

No code change — version strings only.