### PR TITLE
Parse known_good feeds on ArtifactInstance

### DIFF
--- a/specs/02-resources.md
+++ b/specs/02-resources.md
@@ -285,6 +285,16 @@ Supported hash types are listed in `Hashable.SUPPORTED_HASH_TYPES` (`sha1`, `sha
 
 Wraps a single scan instance. Carries `id`, `sha256`, `upload_url`, the assertion / detection counts, the scan metadata.
 
+**`known_good` / `known_good_sources`.** When the server flags this sha256 as a
+known-good binary, the response carries a `known_good` array — one
+`{tool, tool_metadata, created, updated}` entry per flagging feed (`nsrl`,
+`winbindex`, `winget`). `ArtifactInstance.known_good` is that raw list (or `None`
+for a normal artifact / a server too old to emit the field — parsed with `.get()`,
+so older recorded responses parse to `None` with no behaviour change), and
+`known_good_sources` is the sorted, de-duplicated list of feed names derived from
+it (`[]` when not known-good). The field is **display-only** metadata; the
+known-good *state* rides in the per-resource status the server returns, not here.
+
 Classmethod builders (each returns a `PolyswarmRequest` descriptor):
 
 - `exists_hash(api, hash_value, hash_type, require_scan=False)` — HEAD request, returns the status code as the result.

--- a/specs/05-downstream-contract.md
+++ b/specs/05-downstream-contract.md
@@ -251,7 +251,7 @@ The report-template logo upload does **not** go through a dedicated session meth
 
 ## Resource response shapes
 
-The resource classes (`ArtifactInstance`, `HistoricalHunt`, etc.) wrap server JSON. Their attribute names match the JSON keys returned by the server's REST API.
+The resource classes (`ArtifactInstance`, `HistoricalHunt`, etc.) wrap server JSON. Their attribute names match the JSON keys returned by the server's REST API. A few attributes are *derived* convenience views rather than direct keys (e.g. `ArtifactInstance.known_good_sources`, the sorted feed-name list derived from the `known_good` array); these are additive and don't replace the underlying key.
 
 What is part of the contract:
 

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -266,6 +266,15 @@ class ArtifactInstance(core.BaseJsonResource, core.Hashable):
         metadata_json = content.get('metadata') or []
         metadata = {metadata['tool']: metadata['tool_metadata'] for metadata in metadata_json}
         self.metadata = Metadata(metadata, api)
+        # Flagging-feed metadata for a known-good binary: a list of
+        # {tool, tool_metadata, created, updated} entries (one per feed that
+        # flagged this sha256 as known-good), or None for a normal artifact.
+        # Optional + additive — absent on responses from older servers, so use
+        # .get() (older recorded responses parse to None, no behaviour change).
+        self.known_good = content.get('known_good')
+        self.known_good_sources = sorted(
+            {feed['tool'] for feed in self.known_good if feed.get('tool')}
+        ) if self.known_good else []
 
         # ArtifactInstance fields
         self.id = content.get('id')

--- a/test/known_good_test.py
+++ b/test/known_good_test.py
@@ -84,3 +84,45 @@ class TestKnownGoodParsing:
         assert kg.sources == []
         assert kg.created is None
         assert kg.id is None
+
+
+def _instance_content(**overrides):
+    """Minimal valid ArtifactInstance response row (required keys only)."""
+    content = {
+        'sha256': SHA, 'md5': 'c' * 32, 'sha1': 'b' * 40,
+        'mimetype': 'application/x-dosexec', 'size': 68, 'extended_type': '',
+        'first_seen': '2020-01-01T00:00:00', 'upload_url': '', 'metadata': [],
+    }
+    content.update(overrides)
+    return content
+
+
+class TestArtifactInstanceKnownGoodField:
+    """The known_good field on an artifact-instance response (the search/scan
+    result shape), distinct from the KnownGood CRUD resource above."""
+
+    def test_known_good_feeds_are_parsed_and_sources_derived(self):
+        feeds = [
+            {'tool': 'winget', 'tool_metadata': {'product': 'Example'},
+             'created': '2026-06-11T00:00:00', 'updated': '2026-06-11T00:00:00'},
+            {'tool': 'nsrl', 'tool_metadata': {},
+             'created': '2026-06-11T00:00:00', 'updated': '2026-06-11T00:00:00'},
+        ]
+        inst = resources.ArtifactInstance(_instance_content(known_good=feeds))
+        # The raw feed list is preserved verbatim...
+        assert inst.known_good == feeds
+        # ...and the feed (source) names are exposed sorted + de-duplicated.
+        assert inst.known_good_sources == ['nsrl', 'winget']
+
+    def test_absent_known_good_parses_to_none(self):
+        # Older servers omit the field entirely (additive, backward-compatible):
+        # it parses to None with no sources, not a KeyError.
+        inst = resources.ArtifactInstance(_instance_content())
+        assert inst.known_good is None
+        assert inst.known_good_sources == []
+
+    def test_null_known_good_parses_to_none(self):
+        # A normal (non-known-good) artifact has known_good explicitly null.
+        inst = resources.ArtifactInstance(_instance_content(known_good=None))
+        assert inst.known_good is None
+        assert inst.known_good_sources == []


### PR DESCRIPTION
## TL;DR

- Parse a new optional **`known_good`** field on `ArtifactInstance` — the flagging-feed list a known-good binary's search/scan response now carries (one `{tool, tool_metadata, created, updated}` entry per feed), or `None` for a normal artifact.
- Expose **`known_good_sources`** — the sorted, de-duplicated feed names derived from it (`[]` when not known-good).
- Additive and **backward-compatible**: read with `.get()`, so responses from older servers (field absent) parse to `None` with no behaviour change and existing cassettes need no re-record.

## Tests

Pure-unit parse tests (no HTTP): feeds present → raw list preserved + sorted `known_good_sources`; field absent → `None` + `[]`; explicit `null` → `None` + `[]`. Full SDK suite green (142 passed). Specs `02-resources.md` / `05-downstream-contract.md` updated in the same change set.

## Note

Branch renamed to `known-good-feed-metadata` to match the companion artifact-index and polyswarm-cli branches, so CI resolves the matching cross-repo code (the e2e image-tag cascade and the CLI's `$CI_COMMIT_BRANCH` SDK-archive install both key off the branch name). Supersedes the earlier PR #306, which the branch rename closed.