### PR TITLE
feat: expose ArtifactInstance.state (friendly bounty-state name)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyswarm_api"
-version = "4.0.0"
+version = "4.1.0"
 description = "Client library to simplify interacting with the PolySwarm consumer API"
 readme = "README.md"
 requires-python = ">=3.10,<4"
@@ -55,7 +55,7 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.bumpversion]
-current_version = "4.0.0"
+current_version = "4.1.0"
 commit = true
 tag = false
 sign_tags = true

--- a/specs/02-resources.md
+++ b/specs/02-resources.md
@@ -295,6 +295,13 @@ so older recorded responses parse to `None` with no behaviour change), and
 it (`[]` when not known-good). The field is **display-only** metadata; the
 known-good *state* rides in the per-resource status the server returns, not here.
 
+**`state`.** The friendly bounty-state NAME the server returns alongside the
+numeric `bounty_state` — a string such as `'KNOWN_GOOD'` / `'SETTLED'` / `'STORED'`,
+or `None`. Additive and optional (parsed with `.get()`, so a server too old to emit
+it parses to `None` with no behaviour change). It lets a consumer recognise a
+known-good-bypassed scan via `state == 'KNOWN_GOOD'` even when `known_good` above is
+`None` (the sha matched no `KnownGood`). The raw numeric `bounty_state` is unchanged.
+
 Classmethod builders (each returns a `PolyswarmRequest` descriptor):
 
 - `exists_hash(api, hash_value, hash_type, require_scan=False)` — HEAD request, returns the status code as the result.

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '4.0.0'
+__version__ = '4.1.0'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -275,6 +275,10 @@ class ArtifactInstance(core.BaseJsonResource, core.Hashable):
         self.known_good_sources = sorted(
             {feed['tool'] for feed in self.known_good if feed.get('tool')}
         ) if self.known_good else []
+        # Friendly bounty-state NAME (e.g. 'KNOWN_GOOD' / 'SETTLED' / 'STORED'),
+        # additive alongside the numeric bounty_state. Optional — older servers
+        # omit it, so .get() yields None (no behaviour change).
+        self.state = content.get('state')
 
         # ArtifactInstance fields
         self.id = content.get('id')

--- a/test/known_good_test.py
+++ b/test/known_good_test.py
@@ -126,3 +126,21 @@ class TestArtifactInstanceKnownGoodField:
         inst = resources.ArtifactInstance(_instance_content(known_good=None))
         assert inst.known_good is None
         assert inst.known_good_sources == []
+
+
+class TestArtifactInstanceStateField:
+    """The state field on an artifact-instance response — the friendly
+    bounty-state NAME, additive alongside the numeric bounty_state."""
+
+    def test_state_is_parsed(self):
+        inst = resources.ArtifactInstance(_instance_content(state='KNOWN_GOOD'))
+        assert inst.state == 'KNOWN_GOOD'
+
+    def test_absent_state_parses_to_none(self):
+        # Older servers omit the field entirely (additive, backward-compatible).
+        inst = resources.ArtifactInstance(_instance_content())
+        assert inst.state is None
+
+    def test_null_state_parses_to_none(self):
+        inst = resources.ArtifactInstance(_instance_content(state=None))
+        assert inst.state is None


### PR DESCRIPTION
## TL;DR
- Parse a new additive `ArtifactInstance.state` — the friendly bounty-state name the server returns alongside the numeric `bounty_state` (e.g. `'KNOWN_GOOD'` / `'SETTLED'` / `'STORED'`, or `None`).
- Backward-compatible: read with `.get()`, so a server too old to emit the field parses to `None` with no behaviour change.

## Context
The server now emits a string `state` (the bounty-state name) next to `bounty_state`. Exposing it lets a consumer (the CLI) recognise a known-good-bypassed scan via `state == 'KNOWN_GOOD'` even when the `known_good` feed list is `None` (the sha matched no known-good record).

## Changes
- `src/polyswarm_api/resources.py` — `self.state = content.get('state')` on `ArtifactInstance`. `resources.py` is hand-written/shared, so no sync-mirror regen.
- `specs/02-resources.md` — document the `state` attribute (additive, optional, display-only).

## Tests
- `test/known_good_test.py::TestArtifactInstanceStateField` — `state` present → parsed; absent → `None`; null → `None`. Full `known_good_test` suite green (12 passed).

## Requires
- https://github.com/polyswarm/artifact-index/pull/1896 — the server-side `state` field.
