### PR TITLE
Release 4.1.0 — Known Good Binaries SDK surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,12 +90,14 @@ Mirror the existing patterns (`LLMPromptConfig`, `MetadataFieldProperties`, `Yar
 1. `class FooBar(BaseJsonResource): RESOURCE_ENDPOINT = '/…'` in [`resources.py`](./src/polyswarm_api/resources.py). If the resource's identifier isn't `id`, set `RESOURCE_ID_KEYS = ['your_key']` so the base class routes it into the query string for `GET` / `DELETE` / `PUT`. Resources are transport-agnostic — only edit `resources.py`.
 2. Add convenience methods on **[`PolySwarmAsyncAPI`](./src/polyswarm_api/aio/api.py)** (the canonical async source). For a single resource: `return await self._single(resources.FooBar.<builder>(self, …))`. For paginated: `async for item in self._paginate(...): yield item`.
 3. Run `python scripts/regenerate_sync.py` (or rely on the pre-commit hook) to regenerate the sync mirror at `polyswarm_api/api.py`.
-4. Add unit tests for the resource builder (assert the resulting `PolyswarmRequest`'s shape) and `parse_response` behaviour where relevant — no httpx fixtures needed. For end-to-end coverage, add to the parametrised `ClientTestCase` harness in `test/metadata_field_properties_test.py`. See [`specs/04-testing.md`](./specs/04-testing.md).
+4. Add tests **e2e-first** (see [`specs/04-testing.md`](./specs/04-testing.md)): a live-e2e **VCR lifecycle test** against the real endpoint (sync body in `client_scan_test.py`, async in `async_client_test.py`; record the cassettes against a fresh e2e stack and commit them) plus **pure-unit builder tests** (assert the resulting `PolyswarmRequest`'s shape — body-vs-query routing, None-omission; no httpx fixtures needed). Reach for the respx `ClientTestCase` harness only when the scenario can't reasonably run on the e2e stack.
 5. Update [`specs/03-endpoints.md`](./specs/03-endpoints.md) (and any other relevant spec) in the same PR. Commit both `aio/api.py` and the regenerated `api.py`.
 
-## VCR cassette workflow
+## Testing: e2e-first, VCR cassettes for replay
 
-`client_scan_test.py` and `async_client_test.py` use VCR cassettes (`vcrpy`) for tests that hit real PolySwarm endpoints. Cassettes live in `test/vcr/` and use `record_mode='once'` (the default): the first run records, subsequent runs replay.
+**The rule: test against real artifact-index endpoints via the e2e stack; mock only as a last resort.** New endpoint tests are VCR-backed live-e2e tests (`client_scan_test.py` sync / `async_client_test.py` async) — the first run records the real exchange into `test/vcr/` (`record_mode='once'`), subsequent runs replay it offline, and the e2e CI job re-runs everything live with `TESTS_VCR=off`. The respx-mocked `ClientTestCase` tier is reserved for scenarios the e2e stack can't reasonably produce (transport failures, retry exhaustion, external systems); pure-unit covers builder/parse logic with no HTTP at all. Full treatment + decision tree: [`specs/04-testing.md`](./specs/04-testing.md).
+
+**E2e conventions:** the **EICAR variant is the default sample-generation strategy** — any test needing an artifact or a sha derives it from its own EICAR variant via `malicious_artifact(uid)` (deterministic per test, so cassettes replay and xdist workers never collide). And **all tests use only the `eicar` engine** — the stack's single microengine/arbiter pair; never depend on (or start) any other engine.
 
 **To re-record a cassette against the live e2e stack:**
 
@@ -104,7 +106,15 @@ rm test/vcr/<cassette_name>.vcr
 pytest test/<test_file>.py::TestClass::test_method
 ```
 
-The deletion makes VCR record a fresh cassette; the test runs against whatever e2e environment your settings point at.
+The deletion makes VCR record a fresh cassette against the live stack. Cassettes are always produced this way — **never copied from a sibling test** and never hand-edited. Record against a **freshly booted** stack: create-style tests are first-run-safe (their deterministic keys already exist on a reused stack).
+
+**Running against a local pinned stack** (required when pairing with a server-side change; full loop in [`specs/04-testing.md`](./specs/04-testing.md) and artifact-index `specs/03-local-e2e-testing.md`): build the server image locally tagged `:latest`, then `cd ../e2e && e2e init -f && e2e run -pine`, then run the suite from your working tree:
+
+```bash
+TESTS_VCR=off pytest test/ -n 8 --dist worksteal --timeout=600 --timeout-method=thread
+```
+
+`TESTS_VCR=off` makes `@vcr.use_cassette()` a no-op — live HTTP, no replay/record (it's what the e2e CI test image bakes in). If the stack misbehaves, restart it whole (`docker ps -aq --filter name=e2e | xargs -r docker rm -f`, then re-run) — simpler and faster than repairing state.
 
 **VCR matcher convention** (see [`specs/04-testing.md`](./specs/04-testing.md) for the full details): use `[method, scheme, host, port, path, query]` rather than the literal `uri` matcher — the `query` matcher compares params as a set, so cassettes survive httpx's different param-ordering.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyswarm_api"
-version = "4.0.0"
+version = "4.1.0"
 description = "Client library to simplify interacting with the PolySwarm consumer API"
 readme = "README.md"
 requires-python = ">=3.10,<4"
@@ -55,7 +55,7 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.bumpversion]
-current_version = "4.0.0"
+current_version = "4.1.0"
 commit = true
 tag = false
 sign_tags = true

--- a/specs/02-resources.md
+++ b/specs/02-resources.md
@@ -295,6 +295,13 @@ so older recorded responses parse to `None` with no behaviour change), and
 it (`[]` when not known-good). The field is **display-only** metadata; the
 known-good *state* rides in the per-resource status the server returns, not here.
 
+**`state`.** The friendly bounty-state NAME the server returns alongside the
+numeric `bounty_state` — a string such as `'KNOWN_GOOD'` / `'SETTLED'` / `'STORED'`,
+or `None`. Additive and optional (parsed with `.get()`, so a server too old to emit
+it parses to `None` with no behaviour change). It lets a consumer recognise a
+known-good-bypassed scan via `state == 'KNOWN_GOOD'` even when `known_good` above is
+`None` (the sha matched no `KnownGood`). The raw numeric `bounty_state` is unchanged.
+
 Classmethod builders (each returns a `PolyswarmRequest` descriptor):
 
 - `exists_hash(api, hash_value, hash_type, require_scan=False)` — HEAD request, returns the status code as the result.

--- a/specs/02-resources.md
+++ b/specs/02-resources.md
@@ -320,7 +320,7 @@ Several resources add domain-specific classmethods on top of the standard CRUD s
 - `SandboxTask` — `create_file`, `update_file`, `latest`, `my_tasks` for the various sandbox-submission shapes. **No `upload_file` instance method** in 4.0.
 - `Sample` — `create` with `endpoint_fmt={'sha256': sha256}` for the URL-parametrised path.
 - `Webhook` — `test(api, webhook_id)` for the test-payload endpoint.
-- `KnownGood` — `RESOURCE_ENDPOINT = '/known-good'`, `RESOURCE_ID_KEYS = ['sha256']`; `create`/`get`-by-sha256/`delete`-by-id (no update). `get` routes `sha256` + `community` into the query string; `delete` overrides `_delete_params` to route the entry's `id` into the query string (like the other id-keyed delete endpoints — no community/body). Internal-only on the server (gated by the `known_good` feature). API methods: `known_good_create` / `known_good_get(sha256)` / `known_good_delete(known_good_id)`.
+- `KnownGood` — `RESOURCE_ENDPOINT = '/known-good'`, `RESOURCE_ID_KEYS = ['sha256']`; `create`/`get`-by-sha256/`delete`-by-sha256 (no update). `sha256` is the resource's natural unique key and is the key for both retrieve and delete, so the base `_get_params`/`_delete_params` route it into the query string with **no override**: `get` sends `sha256` + `community`; `delete` sends just `sha256` (no community/body). Internal-only on the server (gated by the `known_good` feature). API methods: `known_good_create` / `known_good_get(sha256)` / `known_good_delete(sha256)`.
 
 These follow the same convention: build a `PolyswarmRequest`, return it.
 

--- a/specs/02-resources.md
+++ b/specs/02-resources.md
@@ -285,6 +285,16 @@ Supported hash types are listed in `Hashable.SUPPORTED_HASH_TYPES` (`sha1`, `sha
 
 Wraps a single scan instance. Carries `id`, `sha256`, `upload_url`, the assertion / detection counts, the scan metadata.
 
+**`known_good` / `known_good_sources`.** When the server flags this sha256 as a
+known-good binary, the response carries a `known_good` array — one
+`{tool, tool_metadata, created, updated}` entry per flagging feed (`nsrl`,
+`winbindex`, `winget`). `ArtifactInstance.known_good` is that raw list (or `None`
+for a normal artifact / a server too old to emit the field — parsed with `.get()`,
+so older recorded responses parse to `None` with no behaviour change), and
+`known_good_sources` is the sorted, de-duplicated list of feed names derived from
+it (`[]` when not known-good). The field is **display-only** metadata; the
+known-good *state* rides in the per-resource status the server returns, not here.
+
 Classmethod builders (each returns a `PolyswarmRequest` descriptor):
 
 - `exists_hash(api, hash_value, hash_type, require_scan=False)` — HEAD request, returns the status code as the result.

--- a/specs/02-resources.md
+++ b/specs/02-resources.md
@@ -320,6 +320,7 @@ Several resources add domain-specific classmethods on top of the standard CRUD s
 - `SandboxTask` — `create_file`, `update_file`, `latest`, `my_tasks` for the various sandbox-submission shapes. **No `upload_file` instance method** in 4.0.
 - `Sample` — `create` with `endpoint_fmt={'sha256': sha256}` for the URL-parametrised path.
 - `Webhook` — `test(api, webhook_id)` for the test-payload endpoint.
+- `KnownGood` — `RESOURCE_ENDPOINT = '/known-good'`, `RESOURCE_ID_KEYS = ['sha256']`; standard `create`/`get`/`delete` (no update). Overrides `_delete_params` to route `sha256` **and** `community` into the query string (GET-style) so DELETE carries no body. Internal-only on the server (gated by the `known_good` feature). API methods: `known_good_create` / `known_good_get` / `known_good_delete`.
 
 These follow the same convention: build a `PolyswarmRequest`, return it.
 

--- a/specs/02-resources.md
+++ b/specs/02-resources.md
@@ -320,7 +320,7 @@ Several resources add domain-specific classmethods on top of the standard CRUD s
 - `SandboxTask` — `create_file`, `update_file`, `latest`, `my_tasks` for the various sandbox-submission shapes. **No `upload_file` instance method** in 4.0.
 - `Sample` — `create` with `endpoint_fmt={'sha256': sha256}` for the URL-parametrised path.
 - `Webhook` — `test(api, webhook_id)` for the test-payload endpoint.
-- `KnownGood` — `RESOURCE_ENDPOINT = '/known-good'`, `RESOURCE_ID_KEYS = ['sha256']`; standard `create`/`get`/`delete` (no update). Overrides `_delete_params` to route `sha256` **and** `community` into the query string (GET-style) so DELETE carries no body. Internal-only on the server (gated by the `known_good` feature). API methods: `known_good_create` / `known_good_get` / `known_good_delete`.
+- `KnownGood` — `RESOURCE_ENDPOINT = '/known-good'`, `RESOURCE_ID_KEYS = ['sha256']`; `create`/`get`-by-sha256/`delete`-by-id (no update). `get` routes `sha256` + `community` into the query string; `delete` overrides `_delete_params` to route the entry's `id` into the query string (like the other id-keyed delete endpoints — no community/body). Internal-only on the server (gated by the `known_good` feature). API methods: `known_good_create` / `known_good_get(sha256)` / `known_good_delete(known_good_id)`.
 
 These follow the same convention: build a `PolyswarmRequest`, return it.
 

--- a/specs/03-endpoints.md
+++ b/specs/03-endpoints.md
@@ -39,6 +39,16 @@ The full catalogue of methods on the public client surface and which transport h
 | `metadata_field_properties_get(field_path)` | inline (GET) |
 | `metadata_field_properties_delete(field_path)` | inline (DELETE) |
 
+### Known-good binaries
+
+Internal-only CRUD for the `/known-good` binary resource (distinct from the IOC known-*host* methods below). `sha256` is the natural key for both retrieve and delete, so all three route through the base `KnownGood` param helpers with no override.
+
+| Method | Resource builder |
+|---|---|
+| `known_good_create(sha256, source, sha1=None, md5=None, filename=None, mimetype=None, metadata=None)` | `KnownGood.create` (POST — all fields incl. `community` in the body) |
+| `known_good_get(sha256)` | `KnownGood.get` (GET — `sha256` + `community` in the query) |
+| `known_good_delete(sha256)` | `KnownGood.delete` (DELETE — `sha256` in the query, no community/body) |
+
 ### Known-host CRUD
 
 | Method | Resource builder |

--- a/specs/04-testing.md
+++ b/specs/04-testing.md
@@ -6,13 +6,14 @@ How the test suite is organised. Three layers: pure unit tests (no HTTP at all �
 
 ## Invariants
 
-1. **Tests must pass against the live e2e stack with VCR off.** VCR is an efficiency cache, not a load-bearing requirement. Don't hardcode `record_mode='none'`. If a test only works against the recorded cassette, that's a test bug.
-2. **Cassette re-recording is delete-driven.** `rm test/vcr/<name>.vcr && pytest …<test>` re-records against the live e2e. `record_mode='once'` (the default) makes this work without flag-flipping.
-3. **One cassette serves both transports.** Sync and async tests targeting the same scenario use the same on-the-wire request shape (because both clients run on `httpx`). The VCR matcher is configured so cassettes survive `httpx`'s param-ordering differences from the original `requests`-recorded format — see "VCR matcher convention" below.
-4. **New endpoint tests use the parametrised `ClientTestCase` harness.** It auto-emits `<Name>Sync` and `<Name>Async` siblings so the same body runs against both clients. Don't write parallel sync / async test bodies for new endpoints.
-5. **The HTTP mocking library follows the transport.** Both clients use `httpx`, so `respx` is the mocking library.
-6. **Prefer the pure-unit tier for builder + parse logic.** `PolyswarmRequest` builders are pure data; `parse_response` is a pure function. They're testable without httpx, async, or fixtures. Use this tier for any bug that can be reproduced without network involvement.
-7. **The live VCR-off run is parallel (`pytest -n 8`).** New tests must be isolation-safe: own uniquely-keyed resources (deterministic per-test `uid` — `malicious_artifact(uid)`, `uid_ip` / `uid_host` / `uid_yara`), assert only on their own data, and share no mutable state, so xdist workers never collide. See "Running the suite in parallel" below.
+1. **E2e-first: endpoint behaviour is tested against the real server, not a mocked response.** New endpoint tests call the live e2e stack and record a VCR cassette so unit runs replay it offline. Mock the HTTP boundary (`respx`) **only** when exercising the scenario on the e2e stack is disproportionately costly (e.g. forcing transport-level failures, retry exhaustion, pagination-cursor pathologies the server won't produce) or the dependency is an external system that isn't part of the stack. A fabricated `respx` response asserts what we *think* the server returns; a cassette asserts what it *actually* returned.
+2. **Tests must pass against the live e2e stack with VCR off.** VCR is an efficiency cache, not a load-bearing requirement. Don't hardcode `record_mode='none'`. If a test only works against the recorded cassette, that's a test bug.
+3. **Cassette re-recording is delete-driven, and recording is live-only.** `rm test/vcr/<name>.vcr && pytest …<test>` re-records against the live e2e. `record_mode='once'` (the default) makes this work without flag-flipping. Cassettes are always produced by running the test against the live stack — never copied from a sibling test's cassette and never hand-edited (beyond scrubbing sensitive values).
+4. **One cassette serves both transports.** Sync and async tests targeting the same scenario use the same on-the-wire request shape (because both clients run on `httpx`). The VCR matcher is configured so cassettes survive `httpx`'s param-ordering differences from the original `requests`-recorded format — see "VCR matcher convention" below.
+5. **`respx` tests (where justified under invariant 1) use the parametrised `ClientTestCase` harness.** It auto-emits `<Name>Sync` and `<Name>Async` siblings so the same body runs against both clients. Don't write parallel sync / async respx bodies. (Live/VCR tests can't use this harness — `_AsyncToSync` is respx-only — so they follow the `client_scan_test.py` / `async_client_test.py` pattern instead.)
+6. **The HTTP mocking library follows the transport.** Both clients use `httpx`, so `respx` is the mocking library.
+7. **Prefer the pure-unit tier for builder + parse logic.** `PolyswarmRequest` builders are pure data; `parse_response` is a pure function. They're testable without httpx, async, or fixtures. Use this tier for any bug that can be reproduced without network involvement — including request-shape assertions (body vs query routing, None-omission, bodyless DELETE) that a cassette can't express directly.
+8. **The live VCR-off run is parallel (`pytest -n 8`).** New tests must be isolation-safe: own uniquely-keyed resources (deterministic per-test `uid` — `malicious_artifact(uid)`, `uid_ip` / `uid_host` / `uid_yara`; hash-keyed resources derive their sha from the test's own EICAR variant via `malicious_artifact(uid)`), assert only on their own data, and share no mutable state, so xdist workers never collide. See "Running the suite in parallel" below.
 
 ## Files
 
@@ -32,12 +33,17 @@ The SDK is tested at three levels:
 | Layer | Tool | What it covers | When to use |
 |---|---|---|---|
 | **Pure unit** | none | Resource-builder shape (`Foo.bar(api, ...)` returns a `PolyswarmRequest` with method/url/params as expected). `parse_response` behaviour (`parse_response(fake_response, request)` populates fields or raises). `jmespath`, helpers. | Anything that can be tested without HTTP. Fast, deterministic, no fixtures. |
-| **Mocked I/O** | `respx` | End-to-end call against a mocked httpx transport. The full pipeline runs (api → session → execute → parse_response → resource constructor), but no real network. | Endpoint behaviour that depends on full round-trip + parsing. |
-| **Cassette replay** | `vcrpy` | Records real HTTP exchanges against the live e2e; replays them on subsequent runs. | Real-server correctness, server-shape regression detection. |
+| **Mocked I/O** | `respx` | End-to-end call against a mocked httpx transport. The full pipeline runs (api → session → execute → parse_response → resource constructor), but no real network — the response is fabricated by the test. | **Only** when the live e2e stack can't reasonably produce the scenario: transport-level failures, retry exhaustion, pagination-cursor pathologies, external systems that aren't part of the stack. |
+| **Cassette replay** | `vcrpy` | Records real HTTP exchanges against the live e2e; replays them on subsequent runs. | **The default for endpoint behaviour.** Real-server correctness, server-shape regression detection. |
 
 The pure-unit tier exists because the 4.0 redesign made it possible: resource builders and `parse_response` are pure functions of their inputs. Use it aggressively — a unit test for "did this builder produce the right URL?" runs in microseconds and doesn't break when the test framework changes.
 
-`respx` is preferred for new endpoint tests at the mocked-I/O tier because it's deterministic and fast. VCR is for pinning the contract against the live server.
+**VCR-backed live-e2e tests are the default for new endpoint tests** (invariant 1): they exercise the real server implementation and the cassette pins the actual contract, while replay keeps unit runs fast and offline. `respx` is reserved for scenarios the e2e stack can't produce (or only at disproportionate cost); pure-unit covers request-shape and parse logic without any HTTP. The canonical split for a new endpoint: a live-e2e VCR lifecycle test (behaviour, real contract) + pure-unit builder tests (body-vs-query routing, None-omission) — see `test_known_good_lifecycle` + `test/known_good_test.py`.
+
+### E2e sample-generation conventions
+
+- **The EICAR variant is the default sample-generation strategy.** Any test that needs an artifact — or just a sha256 — derives it from its own EICAR variant via `malicious_artifact(uid)` (`EICAR + uid` → unique content + sha, deterministic per test so cassettes replay). Don't invent parallel strategies (digest-of-test-name, random bytes, checked-in binaries) — one convention keeps every sha attributable to a test and keeps the eicar engine able to flag every sample.
+- **All tests use only the `eicar` engine.** It's the single microengine (+ arbiter) in the e2e stack; tests must not depend on any other engine existing, and local stacks must not grow extra engines for testing. Anything that needs an assertion/verdict gets it from eicar flagging an EICAR-variant sample.
 
 ## The parametrised `ClientTestCase` harness
 
@@ -185,22 +191,19 @@ A single test method's cassette can hold multiple interactions (e.g. `test_submi
 
 Where a sync test and an async test exercise the same scenario, they can share a cassette. The naming convention is to keep two files (`test_X.vcr` and `test_async_X.vcr`) but the content is identical. The parametrised `ClientTestCase` harness sidesteps this entirely — one test name, both clients use it.
 
-For tests still split across `client_scan_test.py` / `async_client_test.py`, when both clients send the same request shape (which is increasingly true now that they share the endpoint surface), it's fine to copy the sync cassette to the async name during migration.
+For tests still split across `client_scan_test.py` / `async_client_test.py`, both clients send the same request shape — but each side still records its **own** cassette (per invariant 3, cassettes are produced by running the test live, never copied from the sibling). The shared matcher just means a sync-recorded cassette *would* replay for the async body; don't rely on that — record both.
 
-## VCR-off mode
+## VCR-off mode (`TESTS_VCR=off`)
 
-A CI matrix entry should run the suite with cassettes hidden, against the live e2e:
+The implemented switch is the `TESTS_VCR` env knob: when `TESTS_VCR=off`, both VCR-configured test modules replace `vcr.use_cassette` with a no-op decorator at import time, so the whole suite runs live — no replay, no recording. `test/conftest.py` also keys off it (real poll pacing, concurrent helpers fan out). This is what the e2e CI job runs (it's baked into the test image: `ENV TESTS_VCR=off` in `docker/Dockerfile`):
 
 ```bash
-pytest --vcr-disabled       # if vcr-pytest plugin is installed; otherwise:
-mv test/vcr test/vcr.disabled
-pytest
-mv test/vcr.disabled test/vcr
+TESTS_VCR=off pytest test/ -n 8 --dist worksteal --timeout=600 --timeout-method=thread
 ```
 
 This proves the SDK works without the cache. The invariant: **every test must pass in VCR-off mode against the live e2e stack**. If a test only works against a recorded cassette, it's a bug in the test.
 
-This is also how cassettes get re-recorded en masse during major SDK changes — delete the directory, run the suite, commit the new cassettes.
+En-masse re-recording during major SDK changes is delete-driven and stays in default (VCR-on) mode: delete the affected cassettes, run the suite against a **freshly booted** e2e stack, commit the new cassettes. (Fresh boot matters: create-style tests are first-run-safe — their deterministic per-test keys already exist on a reused stack.)
 
 ## Running the suite in parallel (`pytest -n`)
 
@@ -260,7 +263,8 @@ Some SDK behaviour depends on the **server** (artifact-index / polyswarmd3), and
      --build-arg PIP_INDEX_URL="$PIP_INDEX_URL" \
      -t 077282062506.dkr.ecr.us-east-2.amazonaws.com/artifact-index:latest .
    ```
-2. Boot the stack with `e2e run -pin` (`--skip-pull --image-default-tag --no-commands`): `-p` keeps your local `:latest` from being overwritten by an ECR pull, `-i` pins the compose default tag, `-n` skips the SDK command step so you run the suite yourself. Then `TESTS_VCR=off pytest test/ -n 8 --dist worksteal` against it. (All *other* images must already be cached locally — warm them with one normal run first.) The authoritative writeup lives in the e2e repo's `specs/04-images-and-registry.md`.
+2. Boot the stack with `e2e run -pine` (`--skip-pull --image-default-tag --no-commands --expose-ports`): `-p` keeps your local `:latest` from being overwritten by an ECR pull, `-i` pins the compose default tag, `-n` skips the SDK command step so you run the suite yourself, and `-e` publishes host ports — required for running the suite from the host (the tests target `artifact-index-e2e:9696`, which resolves to `127.0.0.1` via `/etc/hosts` but only answers when ports are published). Then `TESTS_VCR=off pytest test/ -n 8 --dist worksteal --timeout=600 --timeout-method=thread` against it. (All *other* images must already be cached locally — warm them with one normal run first.) The authoritative writeup lives in the e2e repo's `specs/04-images-and-registry.md`.
+3. Between iterations, tear down before re-booting — a leftover container collides with the fresh boot: `docker ps -aq --filter name=e2e | xargs -r docker rm -f`. **If the stack lands in a bad state, restart it whole** (teardown + fresh `e2e run -pine`) rather than repairing services in place — simpler and faster, and create-style tests are first-run-safe on a fresh DB.
 
 ## The e2e stack is not prod: no read replica, collapsed delays
 
@@ -272,11 +276,11 @@ The fix is a deliberate **~2s gap** (`time.sleep(2)` / `await asyncio.sleep(2)`)
 
 ## Adding a new test
 
-Decision tree:
+Decision tree (e2e-first — see invariant 1):
 
-1. **Pure logic test?** (No HTTP, no resource side effects.) → Plain unittest / pytest function. See `jmespath_test.py`.
-2. **Endpoint test with deterministic mocked response?** → Parametrised `ClientTestCase` with `_MockBoundary`. See `metadata_field_properties_test.py`. Body covers both sync and async automatically.
-3. **End-to-end correctness against the live server?** → VCR-backed test. Record once against e2e, commit the cassette. The test can be sync (in `client_scan_test.py`) or async (in `async_client_test.py`) for now; long-term these migrate to the parametrised harness.
+1. **Pure logic test?** (No HTTP, no resource side effects — including request-builder shape and `parse_response`.) → Plain unittest / pytest function. See `jmespath_test.py`, `core_test.py`, `known_good_test.py`.
+2. **Endpoint behaviour?** → **VCR-backed live-e2e test — the default.** Write the test against the real endpoint, record once against a fresh e2e stack, commit the cassette. Sync body in `client_scan_test.py`, async in `async_client_test.py`. Need a sample or a sha? Derive it from the test's own EICAR variant (`malicious_artifact(uid)`); anything needing a verdict gets it from the `eicar` engine.
+3. **Scenario the e2e stack can't produce** (transport failures, retry exhaustion, cursor pathologies, external systems)? → Parametrised `ClientTestCase` with `_MockBoundary` (`respx`). See `metadata_field_properties_test.py`. Body covers both sync and async automatically. Justify in the test docstring why the scenario can't run on e2e.
 
 Always:
 

--- a/specs/05-downstream-contract.md
+++ b/specs/05-downstream-contract.md
@@ -251,7 +251,7 @@ The report-template logo upload does **not** go through a dedicated session meth
 
 ## Resource response shapes
 
-The resource classes (`ArtifactInstance`, `HistoricalHunt`, etc.) wrap server JSON. Their attribute names match the JSON keys returned by the server's REST API.
+The resource classes (`ArtifactInstance`, `HistoricalHunt`, etc.) wrap server JSON. Their attribute names match the JSON keys returned by the server's REST API. A few attributes are *derived* convenience views rather than direct keys (e.g. `ArtifactInstance.known_good_sources`, the sorted feed-name list derived from the `known_good` array); these are additive and don't replace the underlying key.
 
 What is part of the contract:
 

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '4.0.0'
+__version__ = '4.1.0'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api

--- a/src/polyswarm_api/aio/api.py
+++ b/src/polyswarm_api/aio/api.py
@@ -799,16 +799,16 @@ class PolySwarmAsyncAPI:
         return await self._single(resources.KnownGood.get(
             self, sha256=sha256, community=self.community))
 
-    async def known_good_delete(self, sha256):
+    async def known_good_delete(self, known_good_id):
         """
-        Delete a known-good entry by sha256. Leaves any existing instances intact;
-        only future submissions of that sha256 stop being short-circuited.
-        :param sha256: The sha256 to delete.
-        :return: A KnownGood resource
+        Delete a known-good entry by its id (from create/get). Leaves any existing
+        instances intact; only future submissions of that sha256 stop being
+        short-circuited.
+        :param known_good_id: The KnownGood id to delete.
+        :return: A KnownGood resource (the deletion result)
         """
-        logger.info('Delete known-good %s', sha256)
-        return await self._single(resources.KnownGood.delete(
-            self, sha256=sha256, community=self.community))
+        logger.info('Delete known-good %s', known_good_id)
+        return await self._single(resources.KnownGood.delete(self, id=known_good_id))
 
     async def family_create(self, name):
         """

--- a/src/polyswarm_api/aio/api.py
+++ b/src/polyswarm_api/aio/api.py
@@ -767,6 +767,49 @@ class PolySwarmAsyncAPI:
         async for item in self._paginate(resources.Tag.list(self)):
             yield item
 
+    async def known_good_create(self, sha256, source, sha1=None, md5=None,
+                                filename=None, mimetype=None, metadata=None):
+        """
+        Record a hash as a known-good binary (internal-only). The first feed for a
+        sha256 creates the searchable reference; a different ``source`` for an
+        existing sha256 just records that feed.
+
+        :param sha256: The sha256 of the known-good binary.
+        :param source: The feed/source flagging this hash (becomes a metadata tool).
+        :param sha1: Optional sha1.
+        :param md5: Optional md5.
+        :param filename: Optional filename.
+        :param mimetype: Optional mimetype.
+        :param metadata: Optional dict of extra feed metadata.
+        :return: A KnownGood resource
+        """
+        logger.info('Create known-good %s from %s', sha256, source)
+        return await self._single(resources.KnownGood.create(
+            self, sha256=sha256, source=source, sha1=sha1, md5=md5,
+            filename=filename, mimetype=mimetype, metadata=metadata,
+            community=self.community))
+
+    async def known_good_get(self, sha256):
+        """
+        Fetch a known-good entry by sha256.
+        :param sha256: The sha256 to look up.
+        :return: A KnownGood resource
+        """
+        logger.info('Get known-good %s', sha256)
+        return await self._single(resources.KnownGood.get(
+            self, sha256=sha256, community=self.community))
+
+    async def known_good_delete(self, sha256):
+        """
+        Delete a known-good entry by sha256. Leaves any existing instances intact;
+        only future submissions of that sha256 stop being short-circuited.
+        :param sha256: The sha256 to delete.
+        :return: A KnownGood resource
+        """
+        logger.info('Delete known-good %s', sha256)
+        return await self._single(resources.KnownGood.delete(
+            self, sha256=sha256, community=self.community))
+
     async def family_create(self, name):
         """
         Create a Family.

--- a/src/polyswarm_api/aio/api.py
+++ b/src/polyswarm_api/aio/api.py
@@ -799,16 +799,16 @@ class PolySwarmAsyncAPI:
         return await self._single(resources.KnownGood.get(
             self, sha256=sha256, community=self.community))
 
-    async def known_good_delete(self, known_good_id):
+    async def known_good_delete(self, sha256):
         """
-        Delete a known-good entry by its id (from create/get). Leaves any existing
-        instances intact; only future submissions of that sha256 stop being
-        short-circuited.
-        :param known_good_id: The KnownGood id to delete.
+        Delete a known-good entry by sha256 (the same key used to retrieve it).
+        Leaves any existing instances intact; only future submissions of that
+        sha256 stop being short-circuited.
+        :param sha256: The sha256 of the known-good entry to delete.
         :return: A KnownGood resource (the deletion result)
         """
-        logger.info('Delete known-good %s', known_good_id)
-        return await self._single(resources.KnownGood.delete(self, id=known_good_id))
+        logger.info('Delete known-good %s', sha256)
+        return await self._single(resources.KnownGood.delete(self, sha256=sha256))
 
     async def family_create(self, name):
         """

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -925,6 +925,68 @@ class PolyswarmAPI:
         for item in self._paginate(resources.Tag.list(self)):
             yield item
 
+    def known_good_create(
+        self,
+        sha256,
+        source,
+        sha1=None,
+        md5=None,
+        filename=None,
+        mimetype=None,
+        metadata=None,
+    ):
+        """
+        Record a hash as a known-good binary (internal-only). The first feed for a
+        sha256 creates the searchable reference; a different ``source`` for an
+        existing sha256 just records that feed.
+
+        :param sha256: The sha256 of the known-good binary.
+        :param source: The feed/source flagging this hash (becomes a metadata tool).
+        :param sha1: Optional sha1.
+        :param md5: Optional md5.
+        :param filename: Optional filename.
+        :param mimetype: Optional mimetype.
+        :param metadata: Optional dict of extra feed metadata.
+        :return: A KnownGood resource
+        """
+        logger.info("Create known-good %s from %s", sha256, source)
+        return self._single(
+            resources.KnownGood.create(
+                self,
+                sha256=sha256,
+                source=source,
+                sha1=sha1,
+                md5=md5,
+                filename=filename,
+                mimetype=mimetype,
+                metadata=metadata,
+                community=self.community,
+            )
+        )
+
+    def known_good_get(self, sha256):
+        """
+        Fetch a known-good entry by sha256.
+        :param sha256: The sha256 to look up.
+        :return: A KnownGood resource
+        """
+        logger.info("Get known-good %s", sha256)
+        return self._single(
+            resources.KnownGood.get(self, sha256=sha256, community=self.community)
+        )
+
+    def known_good_delete(self, sha256):
+        """
+        Delete a known-good entry by sha256. Leaves any existing instances intact;
+        only future submissions of that sha256 stop being short-circuited.
+        :param sha256: The sha256 to delete.
+        :return: A KnownGood resource
+        """
+        logger.info("Delete known-good %s", sha256)
+        return self._single(
+            resources.KnownGood.delete(self, sha256=sha256, community=self.community)
+        )
+
     def family_create(self, name):
         """
         Create a Family.

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -975,17 +975,16 @@ class PolyswarmAPI:
             resources.KnownGood.get(self, sha256=sha256, community=self.community)
         )
 
-    def known_good_delete(self, sha256):
+    def known_good_delete(self, known_good_id):
         """
-        Delete a known-good entry by sha256. Leaves any existing instances intact;
-        only future submissions of that sha256 stop being short-circuited.
-        :param sha256: The sha256 to delete.
-        :return: A KnownGood resource
+        Delete a known-good entry by its id (from create/get). Leaves any existing
+        instances intact; only future submissions of that sha256 stop being
+        short-circuited.
+        :param known_good_id: The KnownGood id to delete.
+        :return: A KnownGood resource (the deletion result)
         """
-        logger.info("Delete known-good %s", sha256)
-        return self._single(
-            resources.KnownGood.delete(self, sha256=sha256, community=self.community)
-        )
+        logger.info("Delete known-good %s", known_good_id)
+        return self._single(resources.KnownGood.delete(self, id=known_good_id))
 
     def family_create(self, name):
         """

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -975,16 +975,16 @@ class PolyswarmAPI:
             resources.KnownGood.get(self, sha256=sha256, community=self.community)
         )
 
-    def known_good_delete(self, known_good_id):
+    def known_good_delete(self, sha256):
         """
-        Delete a known-good entry by its id (from create/get). Leaves any existing
-        instances intact; only future submissions of that sha256 stop being
-        short-circuited.
-        :param known_good_id: The KnownGood id to delete.
+        Delete a known-good entry by sha256 (the same key used to retrieve it).
+        Leaves any existing instances intact; only future submissions of that
+        sha256 stop being short-circuited.
+        :param sha256: The sha256 of the known-good entry to delete.
         :return: A KnownGood resource (the deletion result)
         """
-        logger.info("Delete known-good %s", known_good_id)
-        return self._single(resources.KnownGood.delete(self, id=known_good_id))
+        logger.info("Delete known-good %s", sha256)
+        return self._single(resources.KnownGood.delete(self, sha256=sha256))
 
     def family_create(self, name):
         """

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -874,10 +874,9 @@ class KnownGood(core.BaseJsonResource):
 
     @classmethod
     def _delete_params(cls, **kwargs):
-        # Route sha256 AND community into the query string for DELETE (GET-style)
-        # so we don't depend on a request body and the server reads community from
-        # the query, consistent with GET.
-        return cls._params('GET', *cls.RESOURCE_ID_KEYS, **kwargs)
+        # Delete by the entry's id, routed to the query string like the other
+        # id-keyed delete endpoints — no community/body needed.
+        return cls._params('GET', 'id', **kwargs)
 
 
 #####################################################################

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -275,6 +275,10 @@ class ArtifactInstance(core.BaseJsonResource, core.Hashable):
         self.known_good_sources = sorted(
             {feed['tool'] for feed in self.known_good if feed.get('tool')}
         ) if self.known_good else []
+        # Friendly bounty-state NAME (e.g. 'KNOWN_GOOD' / 'SETTLED' / 'STORED'),
+        # additive alongside the numeric bounty_state. Optional — older servers
+        # omit it, so .get() yields None (no behaviour change).
+        self.state = content.get('state')
 
         # ArtifactInstance fields
         self.id = content.get('id')

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -266,6 +266,15 @@ class ArtifactInstance(core.BaseJsonResource, core.Hashable):
         metadata_json = content.get('metadata') or []
         metadata = {metadata['tool']: metadata['tool_metadata'] for metadata in metadata_json}
         self.metadata = Metadata(metadata, api)
+        # Flagging-feed metadata for a known-good binary: a list of
+        # {tool, tool_metadata, created, updated} entries (one per feed that
+        # flagged this sha256 as known-good), or None for a normal artifact.
+        # Optional + additive — absent on responses from older servers, so use
+        # .get() (older recorded responses parse to None, no behaviour change).
+        self.known_good = content.get('known_good')
+        self.known_good_sources = sorted(
+            {feed['tool'] for feed in self.known_good if feed.get('tool')}
+        ) if self.known_good else []
 
         # ArtifactInstance fields
         self.id = content.get('id')

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -860,6 +860,9 @@ class Tag(core.BaseJsonResource):
 
 
 class KnownGood(core.BaseJsonResource):
+    # sha256 is the natural unique key for a known-good entry, and it's the key
+    # for BOTH retrieve and delete — so RESOURCE_ID_KEYS=['sha256'] lets the base
+    # _get_params / _delete_params route it into the query string with no override.
     RESOURCE_ENDPOINT = '/known-good'
     RESOURCE_ID_KEYS = ['sha256']
 
@@ -871,12 +874,6 @@ class KnownGood(core.BaseJsonResource):
         # feed names (metadata tools) that flagged this hash as known-good
         self.sources = content.get('sources', [])
         self.created = core.parse_isoformat(content.get('created'))
-
-    @classmethod
-    def _delete_params(cls, **kwargs):
-        # Delete by the entry's id, routed to the query string like the other
-        # id-keyed delete endpoints — no community/body needed.
-        return cls._params('GET', 'id', **kwargs)
 
 
 #####################################################################

--- a/src/polyswarm_api/resources.py
+++ b/src/polyswarm_api/resources.py
@@ -859,6 +859,27 @@ class Tag(core.BaseJsonResource):
         self.name = content.get('name')
 
 
+class KnownGood(core.BaseJsonResource):
+    RESOURCE_ENDPOINT = '/known-good'
+    RESOURCE_ID_KEYS = ['sha256']
+
+    def __init__(self, content, api=None):
+        super().__init__(content, api=api)
+        self.id = content.get('id')
+        self.sha256 = content.get('sha256')
+        self.artifact_instance_id = content.get('artifact_instance_id')
+        # feed names (metadata tools) that flagged this hash as known-good
+        self.sources = content.get('sources', [])
+        self.created = core.parse_isoformat(content.get('created'))
+
+    @classmethod
+    def _delete_params(cls, **kwargs):
+        # Route sha256 AND community into the query string for DELETE (GET-style)
+        # so we don't depend on a request body and the server reads community from
+        # the query, consistent with GET.
+        return cls._params('GET', *cls.RESOURCE_ID_KEYS, **kwargs)
+
+
 #####################################################################
 # Nested Resources
 #####################################################################

--- a/test/async_client_test.py
+++ b/test/async_client_test.py
@@ -394,6 +394,33 @@ class TestAsyncScanCase:
             known = [r async for r in api.check_known_hosts(ips=[ip])]
             assert any(h.json['host'] == ip and h.json['type'] == 'ip' for h in known)
 
+    @vcr.use_cassette()
+    async def test_async_known_good_lifecycle(self, uid):
+        # Full create → extend → get → delete round-trip against the real
+        # /known-good endpoint (internal-only; the e2e dev key is on the
+        # internal plan). The sha comes from this test's unique EICAR variant
+        # (same convention as the scan tests) => the create branch runs first;
+        # the trailing delete keeps live re-runs deterministic.
+        async with self._api() as api:
+            _content, sha = malicious_artifact(uid)
+            created = await api.known_good_create(
+                sha256=sha, source='nsrl', filename='kg-sample.exe',
+                metadata={'product': 'Example', 'version': '1.0'})
+            assert created.sha256 == sha
+            assert created.sources == ['nsrl']
+            assert created.artifact_instance_id
+            # A second feed flagging the same sha extends the same entry (no new row).
+            extended = await api.known_good_create(sha256=sha, source='winget')
+            assert extended.id == created.id
+            assert extended.sources == ['nsrl', 'winget']
+            got = await api.known_good_get(sha256=sha)
+            assert got.sha256 == sha
+            assert got.sources == ['nsrl', 'winget']
+            deleted = await api.known_good_delete(sha256=sha)
+            assert deleted.sha256 == sha
+            with pytest.raises(exceptions.NotFoundException):
+                await api.known_good_get(sha256=sha)
+
     # ── Sandbox ───────────────────────────────────────────────────────────────
 
     @vcr.use_cassette()

--- a/test/client_scan_test.py
+++ b/test/client_scan_test.py
@@ -760,6 +760,33 @@ class ScanTestCaseV2(TestCase):
         assert any(h.json['host'] == ip and h.json['type'] == 'ip' for h in known)
 
     @vcr.use_cassette()
+    def test_known_good_lifecycle(self):
+        # Full create → extend → get → delete round-trip against the real
+        # /known-good endpoint (internal-only; the e2e dev key is on the
+        # internal plan). The sha comes from this test's unique EICAR variant
+        # (same convention as the scan tests) => the create branch runs first;
+        # the trailing delete keeps live re-runs deterministic.
+        v3api = PolyswarmAPI(self.test_api_key, uri='http://artifact-index-e2e:9696/v3', community='gamma')
+        _content, sha = malicious_artifact(self._testMethodName)
+        created = v3api.known_good_create(
+            sha256=sha, source='nsrl', filename='kg-sample.exe',
+            metadata={'product': 'Example', 'version': '1.0'})
+        assert created.sha256 == sha
+        assert created.sources == ['nsrl']
+        assert created.artifact_instance_id
+        # A second feed flagging the same sha extends the same entry (no new row).
+        extended = v3api.known_good_create(sha256=sha, source='winget')
+        assert extended.id == created.id
+        assert extended.sources == ['nsrl', 'winget']
+        got = v3api.known_good_get(sha256=sha)
+        assert got.sha256 == sha
+        assert got.sources == ['nsrl', 'winget']
+        deleted = v3api.known_good_delete(sha256=sha)
+        assert deleted.sha256 == sha
+        with pytest.raises(exceptions.NotFoundException):
+            v3api.known_good_get(sha256=sha)
+
+    @vcr.use_cassette()
     def test_sandbox_providers(self):
         v3api = PolyswarmAPI(self.test_api_key, uri='http://artifact-index-e2e:9696/v3', community='gamma')
         response = v3api.sandbox_providers()

--- a/test/client_scan_test.py
+++ b/test/client_scan_test.py
@@ -766,7 +766,7 @@ class ScanTestCaseV2(TestCase):
         # internal plan). The sha comes from this test's unique EICAR variant
         # (same convention as the scan tests) => the create branch runs first;
         # the trailing delete keeps live re-runs deterministic.
-        v3api = PolyswarmAPI(self.test_api_key, uri='http://artifact-index-e2e:9696/v3', community='gamma')
+        v3api = PolyswarmAPI(self.test_api_key, uri=f'http://artifact-index-e2e:9696/{self.api_version}', community='gamma')
         _content, sha = malicious_artifact(self._testMethodName)
         created = v3api.known_good_create(
             sha256=sha, source='nsrl', filename='kg-sample.exe',

--- a/test/known_good_test.py
+++ b/test/known_good_test.py
@@ -1,0 +1,81 @@
+"""Tests for the known_good SDK methods.
+
+Each test runs twice — once against the sync ``PolyswarmAPI`` and once against the
+async ``PolySwarmAsyncAPI`` — via the parametrised ``ClientTestCase`` harness
+(reused from metadata_field_properties_test). The HTTP boundary is mocked by
+``respx`` for both transports.
+"""
+from test.metadata_field_properties_test import ClientTestCase
+
+_BASE_URL = 'http://localhost:9696/v3'
+_RESOURCE_URL = f'{_BASE_URL}/known-good'
+
+SHA = 'a' * 64
+
+
+def _sample_row(sha256=SHA, sources=None):
+    return {
+        'id': '12345678901234567',
+        'sha256': sha256,
+        'artifact_instance_id': '98765432109876543',
+        'sources': sources if sources is not None else ['nsrl'],
+        'created': '2026-06-11T00:00:00',
+    }
+
+
+class KnownGoodTestCase(ClientTestCase):
+    def test_create(self):
+        row = _sample_row()
+        self.mock.add('POST', _RESOURCE_URL, json={'result': row, 'status': 'OK'})
+        result = self.api.known_good_create(sha256=SHA, source='nsrl')
+        assert result.sha256 == SHA
+        assert result.sources == ['nsrl']
+        assert result.artifact_instance_id == '98765432109876543'
+        body = self.mock.last_request_body
+        assert body['sha256'] == SHA
+        assert body['source'] == 'nsrl'
+        # community rides in the POST body (the server reads it from query OR json)
+        assert body['community'] == 'gamma'
+
+    def test_create_omits_unset_optionals(self):
+        row = _sample_row()
+        self.mock.add('POST', _RESOURCE_URL, json={'result': row, 'status': 'OK'})
+        self.api.known_good_create(sha256=SHA, source='nsrl')
+        body = self.mock.last_request_body
+        for optional in ('sha1', 'md5', 'filename', 'mimetype', 'metadata'):
+            assert optional not in body, body
+
+    def test_create_with_metadata_and_hashes(self):
+        row = _sample_row()
+        self.mock.add('POST', _RESOURCE_URL, json={'result': row, 'status': 'OK'})
+        self.api.known_good_create(
+            sha256=SHA, source='winget', sha1='b' * 40, md5='c' * 32,
+            filename='setup.exe', mimetype='application/x-dosexec',
+            metadata={'product': 'Example'})
+        body = self.mock.last_request_body
+        assert body['source'] == 'winget'
+        assert body['sha1'] == 'b' * 40
+        assert body['md5'] == 'c' * 32
+        assert body['filename'] == 'setup.exe'
+        assert body['mimetype'] == 'application/x-dosexec'
+        assert body['metadata'] == {'product': 'Example'}
+
+    def test_get(self):
+        row = _sample_row(sources=['nsrl', 'winget'])
+        self.mock.add('GET', _RESOURCE_URL, json={'result': row, 'status': 'OK'})
+        result = self.api.known_good_get(sha256=SHA)
+        assert result.sha256 == SHA
+        assert result.sources == ['nsrl', 'winget']
+        url = self.mock.last_request_url
+        assert f'sha256={SHA}' in url
+        assert 'community=gamma' in url
+
+    def test_delete(self):
+        row = _sample_row()
+        self.mock.add('DELETE', _RESOURCE_URL, json={'result': row, 'status': 'OK'})
+        result = self.api.known_good_delete(sha256=SHA)
+        assert result.sha256 == SHA
+        # sha256 AND community routed into the query string for DELETE (GET-style)
+        url = self.mock.last_request_url
+        assert f'sha256={SHA}' in url
+        assert 'community=gamma' in url

--- a/test/known_good_test.py
+++ b/test/known_good_test.py
@@ -71,11 +71,11 @@ class KnownGoodTestCase(ClientTestCase):
         assert 'community=gamma' in url
 
     def test_delete(self):
-        row = _sample_row()
-        self.mock.add('DELETE', _RESOURCE_URL, json={'result': row, 'status': 'OK'})
-        result = self.api.known_good_delete(sha256=SHA)
-        assert result.sha256 == SHA
-        # sha256 AND community routed into the query string for DELETE (GET-style)
+        self.mock.add('DELETE', _RESOURCE_URL, json={'result': {'id': '777', 'deleted': True}, 'status': 'OK'})
+        result = self.api.known_good_delete(known_good_id='777')
+        assert result.id == '777'
+        # delete is by id (query string), like the other id-keyed delete endpoints;
+        # no community/body involved.
         url = self.mock.last_request_url
-        assert f'sha256={SHA}' in url
-        assert 'community=gamma' in url
+        assert 'id=777' in url
+        assert 'community=' not in url

--- a/test/known_good_test.py
+++ b/test/known_good_test.py
@@ -1,84 +1,86 @@
-"""Tests for the known_good SDK methods.
+"""Pure-unit request-shape tests for the ``KnownGood`` resource builders.
 
-Each test runs twice — once against the sync ``PolyswarmAPI`` and once against the
-async ``PolySwarmAsyncAPI`` — via the parametrised ``ClientTestCase`` harness
-(reused from metadata_field_properties_test). The HTTP boundary is mocked by
-``respx`` for both transports.
+No HTTP at all (the pure-unit tier — see specs/04-testing.md): these pin the
+request *construction* — which fields ride in the JSON body vs the query
+string, that unset optionals are omitted rather than sent as explicit nulls,
+and that DELETE carries no body. Endpoint *behaviour* is covered by the
+live-e2e VCR lifecycle tests (``test_known_good_lifecycle`` in
+client_scan_test.py / ``test_async_known_good_lifecycle`` in
+async_client_test.py), which run the same calls against the real
+``/known-good`` endpoint and replay from cassettes in unit runs.
 """
-from test.metadata_field_properties_test import ClientTestCase
-
-_BASE_URL = 'http://localhost:9696/v3'
-_RESOURCE_URL = f'{_BASE_URL}/known-good'
+from polyswarm_api import resources
 
 SHA = 'a' * 64
 
 
-def _sample_row(sha256=SHA, sources=None):
-    return {
-        'id': '12345678901234567',
-        'sha256': sha256,
-        'artifact_instance_id': '98765432109876543',
-        'sources': sources if sources is not None else ['nsrl'],
-        'created': '2026-06-11T00:00:00',
-    }
+class _FakeApi:
+    uri = 'https://api.example.test'
+    community = 'gamma'
 
 
-class KnownGoodTestCase(ClientTestCase):
-    def test_create(self):
-        row = _sample_row()
-        self.mock.add('POST', _RESOURCE_URL, json={'result': row, 'status': 'OK'})
-        result = self.api.known_good_create(sha256=SHA, source='nsrl')
-        assert result.sha256 == SHA
-        assert result.sources == ['nsrl']
-        assert result.artifact_instance_id == '98765432109876543'
-        body = self.mock.last_request_body
-        assert body['sha256'] == SHA
-        assert body['source'] == 'nsrl'
-        # community rides in the POST body (the server reads it from query OR json)
-        assert body['community'] == 'gamma'
+class TestKnownGoodBuilders:
+    def test_create_routes_everything_to_the_body(self):
+        api = _FakeApi()
+        req = resources.KnownGood.create(
+            api, sha256=SHA, source='nsrl', community=api.community,
+            sha1='b' * 40, md5='c' * 32, filename='setup.exe',
+            mimetype='application/x-dosexec', metadata={'product': 'Example'})
+        assert req.method == 'POST'
+        assert req.url == f'{api.uri}/known-good'
+        # POST routes every field — including community — into the JSON body.
+        assert req.params is None
+        assert req.input_json == {
+            'sha256': SHA, 'source': 'nsrl', 'community': 'gamma',
+            'sha1': 'b' * 40, 'md5': 'c' * 32, 'filename': 'setup.exe',
+            'mimetype': 'application/x-dosexec', 'metadata': {'product': 'Example'},
+        }
+        assert req.result_parser is resources.KnownGood
 
     def test_create_omits_unset_optionals(self):
-        row = _sample_row()
-        self.mock.add('POST', _RESOURCE_URL, json={'result': row, 'status': 'OK'})
-        self.api.known_good_create(sha256=SHA, source='nsrl')
-        body = self.mock.last_request_body
-        for optional in ('sha1', 'md5', 'filename', 'mimetype', 'metadata'):
-            assert optional not in body, body
+        # None-valued optionals are dropped, not serialised as nulls.
+        api = _FakeApi()
+        req = resources.KnownGood.create(
+            api, sha256=SHA, source='nsrl', community=api.community,
+            sha1=None, md5=None, filename=None, mimetype=None, metadata=None)
+        assert req.input_json == {'sha256': SHA, 'source': 'nsrl', 'community': 'gamma'}
 
-    def test_create_with_metadata_and_hashes(self):
-        row = _sample_row()
-        self.mock.add('POST', _RESOURCE_URL, json={'result': row, 'status': 'OK'})
-        self.api.known_good_create(
-            sha256=SHA, source='winget', sha1='b' * 40, md5='c' * 32,
-            filename='setup.exe', mimetype='application/x-dosexec',
-            metadata={'product': 'Example'})
-        body = self.mock.last_request_body
-        assert body['source'] == 'winget'
-        assert body['sha1'] == 'b' * 40
-        assert body['md5'] == 'c' * 32
-        assert body['filename'] == 'setup.exe'
-        assert body['mimetype'] == 'application/x-dosexec'
-        assert body['metadata'] == {'product': 'Example'}
+    def test_get_routes_key_and_community_to_the_query(self):
+        api = _FakeApi()
+        req = resources.KnownGood.get(api, sha256=SHA, community=api.community)
+        assert req.method == 'GET'
+        assert req.url == f'{api.uri}/known-good'
+        assert req.params == {'sha256': SHA, 'community': 'gamma'}
+        assert req.input_json is None
 
-    def test_get(self):
-        row = _sample_row(sources=['nsrl', 'winget'])
-        self.mock.add('GET', _RESOURCE_URL, json={'result': row, 'status': 'OK'})
-        result = self.api.known_good_get(sha256=SHA)
-        assert result.sha256 == SHA
-        assert result.sources == ['nsrl', 'winget']
-        url = self.mock.last_request_url
-        assert f'sha256={SHA}' in url
-        assert 'community=gamma' in url
+    def test_delete_routes_sha256_to_the_query_with_no_body(self):
+        # sha256 ∈ RESOURCE_ID_KEYS routes to the query string via the base
+        # _delete_params — no override, no community, no request body.
+        api = _FakeApi()
+        req = resources.KnownGood.delete(api, sha256=SHA)
+        assert req.method == 'DELETE'
+        assert req.url == f'{api.uri}/known-good'
+        assert req.params == {'sha256': SHA}
+        assert req.input_json is None
 
-    def test_delete(self):
-        self.mock.add('DELETE', _RESOURCE_URL, json={'result': {'sha256': SHA, 'deleted': True}, 'status': 'OK'})
-        result = self.api.known_good_delete(sha256=SHA)
-        assert result.sha256 == SHA
-        # delete is by sha256 (query string) — the same key used to retrieve, routed
-        # by the base _delete_params via RESOURCE_ID_KEYS=['sha256'] with no override
-        # and no community/body involved.
-        url = self.mock.last_request_url
-        assert f'sha256={SHA}' in url
-        assert 'community=' not in url
-        # delete carries no request body — sha256 rides entirely in the query string
-        assert self.mock.last_request_body is None
+
+class TestKnownGoodParsing:
+    def test_parses_full_row(self):
+        row = {'id': '12345678901234567', 'sha256': SHA,
+               'artifact_instance_id': '98765432109876543',
+               'sources': ['nsrl', 'winget'], 'created': '2026-06-11T00:00:00'}
+        kg = resources.KnownGood(row)
+        assert kg.id == '12345678901234567'
+        assert kg.sha256 == SHA
+        assert kg.artifact_instance_id == '98765432109876543'
+        assert kg.sources == ['nsrl', 'winget']
+        assert kg.created.year == 2026
+
+    def test_parses_minimal_delete_row(self):
+        # The delete response carries only {sha256, deleted} — absent fields
+        # parse to safe defaults (no KeyError, created stays None).
+        kg = resources.KnownGood({'sha256': SHA, 'deleted': True})
+        assert kg.sha256 == SHA
+        assert kg.sources == []
+        assert kg.created is None
+        assert kg.id is None

--- a/test/known_good_test.py
+++ b/test/known_good_test.py
@@ -80,3 +80,5 @@ class KnownGoodTestCase(ClientTestCase):
         url = self.mock.last_request_url
         assert f'sha256={SHA}' in url
         assert 'community=' not in url
+        # delete carries no request body — sha256 rides entirely in the query string
+        assert self.mock.last_request_body is None

--- a/test/known_good_test.py
+++ b/test/known_good_test.py
@@ -84,3 +84,45 @@ class TestKnownGoodParsing:
         assert kg.sources == []
         assert kg.created is None
         assert kg.id is None
+
+
+def _instance_content(**overrides):
+    """Minimal valid ArtifactInstance response row (required keys only)."""
+    content = {
+        'sha256': SHA, 'md5': 'c' * 32, 'sha1': 'b' * 40,
+        'mimetype': 'application/x-dosexec', 'size': 68, 'extended_type': '',
+        'first_seen': '2020-01-01T00:00:00', 'upload_url': '', 'metadata': [],
+    }
+    content.update(overrides)
+    return content
+
+
+class TestArtifactInstanceKnownGoodField:
+    """The known_good field on an artifact-instance response (the search/scan
+    result shape), distinct from the KnownGood CRUD resource above."""
+
+    def test_known_good_feeds_are_parsed_and_sources_derived(self):
+        feeds = [
+            {'tool': 'winget', 'tool_metadata': {'product': 'Example'},
+             'created': '2026-06-11T00:00:00', 'updated': '2026-06-11T00:00:00'},
+            {'tool': 'nsrl', 'tool_metadata': {},
+             'created': '2026-06-11T00:00:00', 'updated': '2026-06-11T00:00:00'},
+        ]
+        inst = resources.ArtifactInstance(_instance_content(known_good=feeds))
+        # The raw feed list is preserved verbatim...
+        assert inst.known_good == feeds
+        # ...and the feed (source) names are exposed sorted + de-duplicated.
+        assert inst.known_good_sources == ['nsrl', 'winget']
+
+    def test_absent_known_good_parses_to_none(self):
+        # Older servers omit the field entirely (additive, backward-compatible):
+        # it parses to None with no sources, not a KeyError.
+        inst = resources.ArtifactInstance(_instance_content())
+        assert inst.known_good is None
+        assert inst.known_good_sources == []
+
+    def test_null_known_good_parses_to_none(self):
+        # A normal (non-known-good) artifact has known_good explicitly null.
+        inst = resources.ArtifactInstance(_instance_content(known_good=None))
+        assert inst.known_good is None
+        assert inst.known_good_sources == []

--- a/test/known_good_test.py
+++ b/test/known_good_test.py
@@ -126,3 +126,21 @@ class TestArtifactInstanceKnownGoodField:
         inst = resources.ArtifactInstance(_instance_content(known_good=None))
         assert inst.known_good is None
         assert inst.known_good_sources == []
+
+
+class TestArtifactInstanceStateField:
+    """The state field on an artifact-instance response — the friendly
+    bounty-state NAME, additive alongside the numeric bounty_state."""
+
+    def test_state_is_parsed(self):
+        inst = resources.ArtifactInstance(_instance_content(state='KNOWN_GOOD'))
+        assert inst.state == 'KNOWN_GOOD'
+
+    def test_absent_state_parses_to_none(self):
+        # Older servers omit the field entirely (additive, backward-compatible).
+        inst = resources.ArtifactInstance(_instance_content())
+        assert inst.state is None
+
+    def test_null_state_parses_to_none(self):
+        inst = resources.ArtifactInstance(_instance_content(state=None))
+        assert inst.state is None

--- a/test/known_good_test.py
+++ b/test/known_good_test.py
@@ -71,11 +71,12 @@ class KnownGoodTestCase(ClientTestCase):
         assert 'community=gamma' in url
 
     def test_delete(self):
-        self.mock.add('DELETE', _RESOURCE_URL, json={'result': {'id': '777', 'deleted': True}, 'status': 'OK'})
-        result = self.api.known_good_delete(known_good_id='777')
-        assert result.id == '777'
-        # delete is by id (query string), like the other id-keyed delete endpoints;
-        # no community/body involved.
+        self.mock.add('DELETE', _RESOURCE_URL, json={'result': {'sha256': SHA, 'deleted': True}, 'status': 'OK'})
+        result = self.api.known_good_delete(sha256=SHA)
+        assert result.sha256 == SHA
+        # delete is by sha256 (query string) — the same key used to retrieve, routed
+        # by the base _delete_params via RESOURCE_ID_KEYS=['sha256'] with no override
+        # and no community/body involved.
         url = self.mock.last_request_url
-        assert 'id=777' in url
+        assert f'sha256={SHA}' in url
         assert 'community=' not in url

--- a/test/vcr/test_async_known_good_lifecycle.vcr
+++ b/test/vcr/test_async_known_good_lifecycle.vcr
@@ -1,0 +1,218 @@
+interactions:
+- request:
+    body: '{"sha256":"d474e08e835f8e538f8aeb6944b4bc73a31db2be96625b0bdfe0ab8bf239226b","source":"nsrl","filename":"kg-sample.exe","metadata":{"product":"Example","version":"1.0"},"community":"gamma"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - '11111111111111111111111111111111'
+      connection:
+      - keep-alive
+      content-length:
+      - '189'
+      content-type:
+      - application/json
+      host:
+      - artifact-index-e2e:9696
+      user-agent:
+      - polyswarm_api/4.0.0 (x86_64-Linux-CPython-3.14.4)
+    method: POST
+    uri: http://artifact-index-e2e:9696/v3/known-good
+  response:
+    body:
+      string: '{"result":{"artifact_instance_id":"71168226319048067","created":"2026-06-12T22:01:46.708413+00:00","id":"86356499935604495","sha256":"d474e08e835f8e538f8aeb6944b4bc73a31db2be96625b0bdfe0ab8bf239226b","sources":["nsrl"]},"status":"OK"}
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Authorization
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '235'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Jun 2026 22:01:46 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '111'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"sha256":"d474e08e835f8e538f8aeb6944b4bc73a31db2be96625b0bdfe0ab8bf239226b","source":"winget","community":"gamma"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - '11111111111111111111111111111111'
+      connection:
+      - keep-alive
+      content-length:
+      - '115'
+      content-type:
+      - application/json
+      host:
+      - artifact-index-e2e:9696
+      user-agent:
+      - polyswarm_api/4.0.0 (x86_64-Linux-CPython-3.14.4)
+    method: POST
+    uri: http://artifact-index-e2e:9696/v3/known-good
+  response:
+    body:
+      string: '{"result":{"artifact_instance_id":"71168226319048067","created":"2026-06-12T22:01:46.708413+00:00","id":"86356499935604495","sha256":"d474e08e835f8e538f8aeb6944b4bc73a31db2be96625b0bdfe0ab8bf239226b","sources":["nsrl","winget"]},"status":"OK"}
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Authorization
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '244'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Jun 2026 22:01:46 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '111'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - '11111111111111111111111111111111'
+      connection:
+      - keep-alive
+      host:
+      - artifact-index-e2e:9696
+      user-agent:
+      - polyswarm_api/4.0.0 (x86_64-Linux-CPython-3.14.4)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/known-good?sha256=d474e08e835f8e538f8aeb6944b4bc73a31db2be96625b0bdfe0ab8bf239226b&community=gamma
+  response:
+    body:
+      string: '{"result":{"artifact_instance_id":"71168226319048067","created":"2026-06-12T22:01:46.708413+00:00","id":"86356499935604495","sha256":"d474e08e835f8e538f8aeb6944b4bc73a31db2be96625b0bdfe0ab8bf239226b","sources":["nsrl","winget"]},"status":"OK"}
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Authorization
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '244'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Jun 2026 22:01:46 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '111'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - '11111111111111111111111111111111'
+      connection:
+      - keep-alive
+      host:
+      - artifact-index-e2e:9696
+      user-agent:
+      - polyswarm_api/4.0.0 (x86_64-Linux-CPython-3.14.4)
+    method: DELETE
+    uri: http://artifact-index-e2e:9696/v3/known-good?sha256=d474e08e835f8e538f8aeb6944b4bc73a31db2be96625b0bdfe0ab8bf239226b
+  response:
+    body:
+      string: '{"result":{"deleted":true,"sha256":"d474e08e835f8e538f8aeb6944b4bc73a31db2be96625b0bdfe0ab8bf239226b"},"status":"OK"}
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Authorization
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Jun 2026 22:01:46 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '111'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - '11111111111111111111111111111111'
+      connection:
+      - keep-alive
+      host:
+      - artifact-index-e2e:9696
+      user-agent:
+      - polyswarm_api/4.0.0 (x86_64-Linux-CPython-3.14.4)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/known-good?sha256=d474e08e835f8e538f8aeb6944b4bc73a31db2be96625b0bdfe0ab8bf239226b&community=gamma
+  response:
+    body:
+      string: '{"errors":null,"result":"No known-good entry found for sha256 d474e08e835f8e538f8aeb6944b4bc73a31db2be96625b0bdfe0ab8bf239226b.","status":"error"}
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Authorization
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Jun 2026 22:01:46 GMT
+      Server:
+      - gunicorn
+    status:
+      code: 404
+      message: NOT FOUND
+version: 1

--- a/test/vcr/test_known_good_lifecycle.vcr
+++ b/test/vcr/test_known_good_lifecycle.vcr
@@ -1,0 +1,218 @@
+interactions:
+- request:
+    body: '{"sha256":"9c0258ed4cc98056773bcf0c57fe4bc79618802357f0703c503b4cb172a263df","source":"nsrl","filename":"kg-sample.exe","metadata":{"product":"Example","version":"1.0"},"community":"gamma"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - '11111111111111111111111111111111'
+      connection:
+      - keep-alive
+      content-length:
+      - '189'
+      content-type:
+      - application/json
+      host:
+      - artifact-index-e2e:9696
+      user-agent:
+      - polyswarm_api/4.0.0 (x86_64-Linux-CPython-3.14.4)
+    method: POST
+    uri: http://artifact-index-e2e:9696/v3/known-good
+  response:
+    body:
+      string: '{"result":{"artifact_instance_id":"90917448071940878","created":"2026-06-12T22:01:46.572994+00:00","id":"18577785917417703","sha256":"9c0258ed4cc98056773bcf0c57fe4bc79618802357f0703c503b4cb172a263df","sources":["nsrl"]},"status":"OK"}
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Authorization
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '235'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Jun 2026 22:01:46 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '111'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"sha256":"9c0258ed4cc98056773bcf0c57fe4bc79618802357f0703c503b4cb172a263df","source":"winget","community":"gamma"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - '11111111111111111111111111111111'
+      connection:
+      - keep-alive
+      content-length:
+      - '115'
+      content-type:
+      - application/json
+      host:
+      - artifact-index-e2e:9696
+      user-agent:
+      - polyswarm_api/4.0.0 (x86_64-Linux-CPython-3.14.4)
+    method: POST
+    uri: http://artifact-index-e2e:9696/v3/known-good
+  response:
+    body:
+      string: '{"result":{"artifact_instance_id":"90917448071940878","created":"2026-06-12T22:01:46.572994+00:00","id":"18577785917417703","sha256":"9c0258ed4cc98056773bcf0c57fe4bc79618802357f0703c503b4cb172a263df","sources":["nsrl","winget"]},"status":"OK"}
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Authorization
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '244'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Jun 2026 22:01:46 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '111'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - '11111111111111111111111111111111'
+      connection:
+      - keep-alive
+      host:
+      - artifact-index-e2e:9696
+      user-agent:
+      - polyswarm_api/4.0.0 (x86_64-Linux-CPython-3.14.4)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/known-good?sha256=9c0258ed4cc98056773bcf0c57fe4bc79618802357f0703c503b4cb172a263df&community=gamma
+  response:
+    body:
+      string: '{"result":{"artifact_instance_id":"90917448071940878","created":"2026-06-12T22:01:46.572994+00:00","id":"18577785917417703","sha256":"9c0258ed4cc98056773bcf0c57fe4bc79618802357f0703c503b4cb172a263df","sources":["nsrl","winget"]},"status":"OK"}
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Authorization
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '244'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Jun 2026 22:01:46 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '111'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - '11111111111111111111111111111111'
+      connection:
+      - keep-alive
+      host:
+      - artifact-index-e2e:9696
+      user-agent:
+      - polyswarm_api/4.0.0 (x86_64-Linux-CPython-3.14.4)
+    method: DELETE
+    uri: http://artifact-index-e2e:9696/v3/known-good?sha256=9c0258ed4cc98056773bcf0c57fe4bc79618802357f0703c503b4cb172a263df
+  response:
+    body:
+      string: '{"result":{"deleted":true,"sha256":"9c0258ed4cc98056773bcf0c57fe4bc79618802357f0703c503b4cb172a263df"},"status":"OK"}
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Authorization
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Jun 2026 22:01:46 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '111'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - '11111111111111111111111111111111'
+      connection:
+      - keep-alive
+      host:
+      - artifact-index-e2e:9696
+      user-agent:
+      - polyswarm_api/4.0.0 (x86_64-Linux-CPython-3.14.4)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/known-good?sha256=9c0258ed4cc98056773bcf0c57fe4bc79618802357f0703c503b4cb172a263df&community=gamma
+  response:
+    body:
+      string: '{"errors":null,"result":"No known-good entry found for sha256 9c0258ed4cc98056773bcf0c57fe4bc79618802357f0703c503b4cb172a263df.","status":"error"}
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Authorization
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Jun 2026 22:01:46 GMT
+      Server:
+      - gunicorn
+    status:
+      code: 404
+      message: NOT FOUND
+version: 1


### PR DESCRIPTION
## TL;DR

The `develop → master` release for **polyswarm-api 4.1.0** (`4.0.0 → 4.1.0`). Minor, fully **additive**: the Known Good Binaries SDK surface — a new `KnownGood` CRUD resource plus two new `ArtifactInstance` fields. **No breaking changes.** Merging to `master` fires the public PyPI publish (`release-pypi`) of 4.1.0.

Brings the Known Good Binaries work already integrated on `develop` to `master`.

## Release notes

### Features
- New **`KnownGood`** resource (`/known-good`, keyed on `sha256`) with client methods `known_good_create(sha256, source, …)` / `known_good_get(sha256)` / `known_good_delete(sha256)` on both the sync and async clients. (The endpoint is internal-only — gated server-side.)
- **`ArtifactInstance.known_good`** — the flagging-feed list a known-good binary's response carries (one `{tool, tool_metadata, created, updated}` entry per feed, or `None` for a normal artifact) — plus **`ArtifactInstance.known_good_sources`**, the sorted, de-duplicated feed names derived from it.
- **`ArtifactInstance.state`** — the friendly bounty-state name returned alongside the numeric `bounty_state` (e.g. `'KNOWN_GOOD'` / `'SETTLED'` / `'STORED'`, or `None`).

### Changes
- The new `ArtifactInstance` fields are additive and backward-compatible — parsed defensively, so responses from an older server (fields absent) parse to `None` / `[]` with no behaviour change, and existing cassettes need no re-record.

### Breaking changes
- None.
