### PR TITLE
test: fix intermittent test_sample e2e race (poll on sandbox+report postconditions)

### DIFF
--- a/test/async_client_test.py
+++ b/test/async_client_test.py
@@ -510,11 +510,25 @@ class TestAsyncScanCase:
             await _complete_sandbox_task(cape.id, 'cape')
             await _complete_sandbox_task(triage.id, 'triage')
 
+            # Poll until BOTH sandbox deps read COMPLETED *and* the LLM report was
+            # auto-triggered — the exact postconditions asserted below, not a proxy.
+            # Keying off llm_report alone raced: the report auto-triggers on *any
+            # one* completed dep (the scan or a single sandbox), so a response can
+            # show it triggered while sandbox_cape still projects NOT_TRIGGERED (the
+            # per-task projection doesn't update atomically). This test drives both
+            # sandboxes to SUCCEEDED, so both projections reach COMPLETED; waiting on
+            # them directly closes the window. See sync test_sample.
             _PRE_TRIGGER = {None, 'NOT_TRIGGERED', 'WAITING_FOR_OTHER_TASKS'}
             result = await api.sample(sha)
             for _ in range(90):
                 result = await api.sample(sha)
-                if result.tasks.get('llm_report', {}).get('requested_status') not in _PRE_TRIGGER:
+                tasks = result.tasks or {}
+                sandboxes_completed = all(
+                    tasks.get(f'sandbox_{s}', {}).get('requested_status') == 'COMPLETED'
+                    for s in ('cape', 'triage')
+                )
+                llm_triggered = tasks.get('llm_report', {}).get('requested_status') not in _PRE_TRIGGER
+                if sandboxes_completed and llm_triggered:
                     break
                 await asyncio.sleep(1)
         assert isinstance(result.artifact_instance, dict)

--- a/test/client_scan_test.py
+++ b/test/client_scan_test.py
@@ -880,18 +880,35 @@ class ScanTestCaseV2(TestCase):
         _complete_sandbox_task(cape.id, 'cape')
         _complete_sandbox_task(triage.id, 'triage')
 
-        # Poll the sample until the LLM report has been auto-triggered. The view
-        # triggers it once a sandbox dep is COMPLETED, so the report's status
-        # moves NOT_TRIGGERED/WAITING_FOR_OTHER_TASKS -> PENDING (then FAILED here,
-        # since e2e has no OPENAI_API_KEY). We key off requested_status: the
-        # requested_id stays null until a report actually renders, which can't
-        # happen without an LLM. Reaching a triggered status also confirms the
-        # sandbox deps completed.
+        # Poll the sample until BOTH sandbox deps read COMPLETED *and* the LLM
+        # report has been auto-triggered — i.e. wait on the exact postconditions
+        # asserted below, not a proxy for them. The report's requested_status moves
+        # NOT_TRIGGERED/WAITING_FOR_OTHER_TASKS -> PENDING (then FAILED here, since
+        # e2e has no OPENAI_API_KEY); requested_id stays null until a report
+        # actually renders (impossible without an LLM), so requested_status is the
+        # trigger signal.
+        #
+        # Keying the loop off llm_report alone raced: the report auto-triggers as
+        # soon as *any one* dependency completes (the scan or a single sandbox), so
+        # a response can show it triggered while sandbox_cape still projects
+        # NOT_TRIGGERED — the delayed COLLECTING_DATA->SUCCEEDED transition (see
+        # _complete_sandbox_task) not yet folded into the per-task projection, which
+        # doesn't update atomically. That mismatch was the flake. This test drives
+        # BOTH sandboxes to SUCCEEDED before polling, so both projections do reach
+        # COMPLETED; waiting on them directly (not on the report as a proxy) closes
+        # the window. A 90x1s timeout here therefore means a dependency never
+        # settled — the scan's bounty window or a sandbox — not this loop.
         _PRE_TRIGGER = {None, 'NOT_TRIGGERED', 'WAITING_FOR_OTHER_TASKS'}
         result = api.sample(sha)
         for _ in range(90):
             result = api.sample(sha)
-            if result.tasks.get('llm_report', {}).get('requested_status') not in _PRE_TRIGGER:
+            tasks = result.tasks or {}
+            sandboxes_completed = all(
+                tasks.get(f'sandbox_{s}', {}).get('requested_status') == 'COMPLETED'
+                for s in ('cape', 'triage')
+            )
+            llm_triggered = tasks.get('llm_report', {}).get('requested_status') not in _PRE_TRIGGER
+            if sandboxes_completed and llm_triggered:
                 break
             time.sleep(1)
         assert isinstance(result.artifact_instance, dict)


### PR DESCRIPTION
## TL;DR

- `test_sample` (sync `ScanTestCaseV2` + async `TestAsyncScanCase.test_async_sample`) is intermittently flaky against a live stack: `AssertionError: assert 'NOT_TRIGGERED' == 'COMPLETED'` on `result.tasks['sandbox_cape']['requested_status']`.
- Root cause is **test logic**, not the SDK or server: the poll loop broke as soon as `llm_report` left its pre-trigger states, then asserted a *different* task (`sandbox_cape`/`sandbox_triage`) was `COMPLETED`.
- The report auto-triggers on **any one** completed dependency, and the sample's per-task `requested_status` fields don't update atomically — so the report can read triggered in the same response where `sandbox_cape` still projects `NOT_TRIGGERED`.
- Fix: poll on the **exact postconditions asserted** — break once both sandbox deps read `COMPLETED` *and* the report is triggered. Comment-only + loop-condition change; assertions unchanged.

## What changed

Both the sync and async `test_sample` swap this proxy exit condition:

```python
if result.tasks.get('llm_report', {}).get('requested_status') not in _PRE_TRIGGER:
    break
```

for one that waits on what the test actually asserts:

```python
tasks = result.tasks or {}
sandboxes_completed = all(
    tasks.get(f'sandbox_{s}', {}).get('requested_status') == 'COMPLETED'
    for s in ('cape', 'triage')
)
llm_triggered = tasks.get('llm_report', {}).get('requested_status') not in _PRE_TRIGGER
if sandboxes_completed and llm_triggered:
    break
```

The test already drives both sandboxes to `SUCCEEDED` before polling, so this only closes the projection-lag window; it never waits on anything the old loop didn't already require.

## Cassette safety

No re-recording needed. At the interaction where the old loop broke, both sandboxes already project `COMPLETED` in the committed cassettes, so the new combined condition breaks at the identical interaction. Verified in replay: the two `test_sample` cases pass, and the full `client_scan_test.py` + `async_client_test.py` replay is green (77 passed). The live (`TESTS_VCR=off`) path is the one this actually hardens.