### PR TITLE
fix: restore pre-4.0 204 ("no results") handling for exists() and downloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyswarm_api"
-version = "4.1.0"
+version = "4.2.0"
 description = "Client library to simplify interacting with the PolySwarm consumer API"
 readme = "README.md"
 requires-python = ">=3.10,<4"
@@ -55,7 +55,7 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.bumpversion]
-current_version = "4.1.0"
+current_version = "4.2.0"
 commit = true
 tag = false
 sign_tags = true

--- a/specs/01-architecture.md
+++ b/specs/01-architecture.md
@@ -270,7 +270,7 @@ Every HTTP-level error maps to a subclass of `PolyswarmException`:
 - 404 → `NotFoundException`
 - 422 → `FailedInstanceException`
 - 429 → `UsageLimitsExceededException`
-- 204 + JSON parser expected → `NoResultsException`
+- 204 on a request that expects data (JSON-parser GET **or** streaming download) → `NoResultsException` — the server did the work but matched nothing. **HEAD is exempt**: it returns the raw status code as the result (so `exists()` reads a 204 as "known-absent" rather than raising).
 - Other non-2xx → `RequestException`
 - Client-side validation failures (bad hash, missing kwarg) → `InvalidValueException`
 - Polling timeouts → `TimeoutException`

--- a/specs/03-endpoints.md
+++ b/specs/03-endpoints.md
@@ -25,7 +25,7 @@ The full catalogue of methods on the public client surface and which transport h
 
 | Method | Resource builder | Notes |
 |---|---|---|
-| `exists(hash_, hash_type=None, require_scan=False)` | `ArtifactInstance.exists_hash` | HEAD; returns `bool` from status code. |
+| `exists(hash_, hash_type=None, require_scan=False)` | `ArtifactInstance.exists_hash` | HEAD; `bool` from status code — `True` **only** for `200` (present). `204` means "absent" (the request succeeded but matched no artifact) and `404` also maps to absent, so both are `False`. Do **not** treat this as a generic `2xx` check: `204` is a successful status that means the opposite of "exists". |
 | `lookup(scan)` | `ArtifactInstance.lookup_uuid` | |
 | `rescan(hash_, hash_type=None, scan_config=None)` | `ArtifactInstance.rescan` | |
 | `rescan_id(scan, scan_config=None)` | `ArtifactInstance.rescan_id` | |

--- a/specs/99-open-questions.md
+++ b/specs/99-open-questions.md
@@ -114,6 +114,7 @@ The 4.0 transport originally buffered (the adapter read `response.content` whole
 - detects a streaming parser (`request.result_parser is not None and not issubclass(request.result_parser, BaseJsonResource)`) and routes to `_execute_download`;
 - opens the response with `self._client.send(req, stream=True)` (status/headers available, body not read) — which also covers the auth-stripped off-domain S3 case (`download_archive`), since header suppression already goes through `build_request` + pop;
 - maps non-2xx via the shared `core._raise_for_status` (identical typed exceptions to the JSON path) after `aread()`-ing the small error body;
+- treats a **204 as "no matching artifact"** (the request succeeded but returned nothing) and raises `NoResultsException` — mirroring the shared `parse_response` 204 rule that the streaming path otherwise bypasses, so an absent download surfaces "no results" instead of silently writing a successful empty file (regression-guarded by `test_async_download_204_raises_no_results`);
 - has the parser class resolve a destination handle (`LocalArtifact.open_destination`), streams the body in chunk by chunk (`response.aiter_bytes(DOWNLOAD_CHUNK_SIZE)`), wraps the written handle (`LocalArtifact.from_written`), and removes a partially-written file it created;
 - closes the response in a `finally` (`aclose`).
 

--- a/src/polyswarm_api/__init__.py
+++ b/src/polyswarm_api/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names
-__version__ = '4.1.0'
+__version__ = '4.2.0'
 __release_url__ = 'https://api.github.com/repos/polyswarm/polyswarm-api/releases/latest'
 
 from . import api

--- a/src/polyswarm_api/aio/api.py
+++ b/src/polyswarm_api/aio/api.py
@@ -1652,8 +1652,11 @@ class PolySwarmAsyncAPI:
                 self, hash_.hash, hash_.hash_type, require_scan=require_scan,
             ),
         )
-        # exists_hash is a HEAD; ``result`` is the status code. Any 2xx means the
-        # artifact is known — the endpoint returns 200 for present / 404 for absent,
-        # so a 2xx check is correct and not brittle to a non-200 success code.
-        return int(result) // 100 == 2
+        # exists_hash is a HEAD; ``result`` is the status code. The endpoint returns
+        # 200 when the artifact is present and 204 when it is absent ("the request
+        # worked, but there was no matching artifact, so nothing was returned"). Only
+        # a 200 means the artifact exists — 204 (and 404) both mean "absent" → False.
+        # NB: this is deliberately ``== 200``, not a ``// 100 == 2`` 2xx check, because
+        # 204 is a successful 2xx that means the opposite of "exists".
+        return int(result) == 200
 

--- a/src/polyswarm_api/aio/session.py
+++ b/src/polyswarm_api/aio/session.py
@@ -148,6 +148,19 @@ class AsyncPolyswarmSession:
                 await response.aread()
                 _raise_for_status(response, request)
 
+            if response.status_code == 204:
+                # A 204 is the "no data / absent" signal on a download: the request
+                # succeeded but there is nothing to write ("the request worked, but
+                # there was no matching artifact, so nothing was returned"). The
+                # shared ``parse_response`` maps a parser-backed 204 to
+                # ``NoResultsException``; the streaming path bypasses ``parse_response``,
+                # so mirror that rule explicitly here. Without it, an absent artifact
+                # would be written out as a successful *empty* file instead of
+                # surfacing "no results".
+                raise exceptions.NoResultsException(
+                    request, 'The request returned no results.',
+                )
+
             pk = request.parser_kwargs or {}
             handle, name, created = request.result_parser.open_destination(
                 pk.get('folder'), pk.get('handle'), pk.get('artifact_name'), response,

--- a/src/polyswarm_api/api.py
+++ b/src/polyswarm_api/api.py
@@ -2002,7 +2002,10 @@ class PolyswarmAPI:
                 require_scan=require_scan,
             ),
         )
-        # exists_hash is a HEAD; ``result`` is the status code. Any 2xx means the
-        # artifact is known — the endpoint returns 200 for present / 404 for absent,
-        # so a 2xx check is correct and not brittle to a non-200 success code.
-        return int(result) // 100 == 2
+        # exists_hash is a HEAD; ``result`` is the status code. The endpoint returns
+        # 200 when the artifact is present and 204 when it is absent ("the request
+        # worked, but there was no matching artifact, so nothing was returned"). Only
+        # a 200 means the artifact exists — 204 (and 404) both mean "absent" → False.
+        # NB: this is deliberately ``== 200``, not a ``// 100 == 2`` 2xx check, because
+        # 204 is a successful 2xx that means the opposite of "exists".
+        return int(result) == 200

--- a/src/polyswarm_api/session.py
+++ b/src/polyswarm_api/session.py
@@ -151,6 +151,20 @@ class PolyswarmSession:
                 response.read()
                 _raise_for_status(response, request)
 
+            if response.status_code == 204:
+                # A 204 is the "no data / absent" signal on a download: the request
+                # succeeded but there is nothing to write ("the request worked, but
+                # there was no matching artifact, so nothing was returned"). The
+                # shared ``parse_response`` maps a parser-backed 204 to
+                # ``NoResultsException``; the streaming path bypasses ``parse_response``,
+                # so mirror that rule explicitly here. Without it, an absent artifact
+                # would be written out as a successful *empty* file instead of
+                # surfacing "no results".
+                raise exceptions.NoResultsException(
+                    request,
+                    "The request returned no results.",
+                )
+
             pk = request.parser_kwargs or {}
             handle, name, created = request.result_parser.open_destination(
                 pk.get("folder"),

--- a/test/async_client_test.py
+++ b/test/async_client_test.py
@@ -993,6 +993,28 @@ async def test_async_download():
 
 
 @respx.mock
+async def test_async_download_204_raises_no_results():
+    """A 204 on a download means "no matching artifact" (the request worked but
+    returned nothing), so the streaming path must raise ``NoResultsException``
+    rather than write out a successful *empty* file — mirroring the shared
+    ``parse_response`` 204 rule that the streaming path otherwise bypasses."""
+    import tempfile, os
+
+    respx.get(f'{BASE_URL}/consumer/download/sha256/{SHA256}').mock(
+        return_value=httpx.Response(204))
+
+    api = PolySwarmAsyncAPI(API_KEY, uri=BASE_URL, community='gamma')
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.raises(exceptions.NoResultsException):
+                await api.download(tmp_dir, SHA256)
+            # No empty artifact file should have been left behind.
+            assert os.listdir(tmp_dir) == []
+    finally:
+        await api.aclose()
+
+
+@respx.mock
 async def test_async_download_streams_in_chunks(monkeypatch):
     """Regression guard for the streaming-download fix: the body is consumed via
     the streaming API (``iter_bytes``) straight into the destination, not read
@@ -1028,17 +1050,18 @@ async def test_async_download_streams_in_chunks(monkeypatch):
 
 
 @respx.mock
-async def test_async_exists_maps_2xx_true_404_false():
-    """End-to-end ``exists`` (the path the bot flagged as untested): the HEAD
-    status drives the result — any 2xx is True, 404 is False. Also locks the 2xx
-    generalisation (not a brittle ``== 200``)."""
+async def test_async_exists_maps_200_true_204_and_404_false():
+    """End-to-end ``exists``: the HEAD status drives the result. The endpoint
+    returns 200 when the artifact is present and 204 when it is absent ("request
+    worked, no matching artifact"), so only a 200 is True — a 204 is a successful
+    2xx that means the *opposite* of "exists" and must be False, as must a 404."""
     route = respx.head(f'{BASE_URL}/search/hash/sha256')
     api = PolySwarmAsyncAPI(API_KEY, uri=BASE_URL, community='gamma')
     try:
         route.mock(return_value=httpx.Response(200))
         assert await api.exists(SHA256) is True
-        route.mock(return_value=httpx.Response(204))   # 2xx-but-not-200 still "exists"
-        assert await api.exists(SHA256) is True
+        route.mock(return_value=httpx.Response(204))   # absent: "worked, nothing found"
+        assert await api.exists(SHA256) is False
         route.mock(return_value=httpx.Response(404))
         assert await api.exists(SHA256) is False
     finally:

--- a/test/core_test.py
+++ b/test/core_test.py
@@ -181,6 +181,17 @@ class TestParseResponse:
         parse_response(_FakeResponse(status_code=404), req)
         assert req._result == 404
 
+    def test_head_204_does_not_raise(self):
+        # A 204 on a HEAD is the "absent" signal for ``exists_hash`` (the
+        # search/hash endpoint returns 200 present / 204 absent). The HEAD
+        # branch short-circuits before the 204 -> NoResultsException mapping
+        # that applies to parser-backed GETs, so ``exists`` receives the raw
+        # 204 as the result and reads it as "not present" (see
+        # ``PolySwarmAsyncAPI.exists``: only 200 is True).
+        req = PolyswarmRequest(api=_FakeApi(), method='HEAD', url='u')
+        parse_response(_FakeResponse(status_code=204), req)
+        assert req._result == 204
+
     def test_2xx_without_parser_is_fire_and_forget(self):
         # No result_parser → body intentionally discarded (e.g. Webhook.test)
         req = PolyswarmRequest(api=_FakeApi(), method='POST', url='u')


### PR DESCRIPTION
## TL;DR
- Restore pre-4.0 handling of HTTP **204** — a *successful* response meaning "the request worked, but nothing matched, so nothing was returned" — that 4.0 broke by widening two status-code checks.
- `exists()` now returns `True` **only** for `200`. A `204` (artifact absent) is correctly `False`; previously *any* 2xx counted, so absent artifacts were reported as existing.
- Streaming **downloads** now raise `NoResultsException` on a `204` instead of silently writing a successful *empty* artifact.
- Canonical async sources edited; sync mirrors regenerated via `scripts/regenerate_sync.py`. New regression tests + spec updates.

## Background
`HEAD /search/hash/{type}` returns `200` when the artifact is present and `204` when it is absent. 4.0 changed `exists()` from `str(result) == '200'` to `int(result) // 100 == 2`, so a `204` (absent) was reported as `True`. Separately, the streaming-download rewrite dropped the shared `204 → NoResultsException` rule, so a `204` download wrote a 0-byte artifact and returned success. This reverts both to the pre-4.0 behavior.

## Changes
**`exists()` — 200-only**
- `src/polyswarm_api/aio/api.py` (canonical) → `return int(result) == 200`; regenerated `src/polyswarm_api/api.py`. Mapping: `200 → True`, `204 → False`, `404 → False`.

**Streaming download — `204 → NoResultsException`**
- `src/polyswarm_api/aio/session.py` `_execute_download` now raises `NoResultsException` on a `204` (before opening the destination); regenerated `src/polyswarm_api/session.py`.

**Tests**
- `test_async_exists_maps_200_true_204_and_404_false` (replaces `..._2xx_true_404_false`, which pinned the bug).
- `test_head_204_does_not_raise` — parse-layer guard: a HEAD `204` returns the raw code without raising, so `exists()` reads it as "absent".
- `test_async_download_204_raises_no_results`.

**Specs**
- `specs/03-endpoints.md`, `specs/01-architecture.md`, `specs/99-open-questions.md` — pin the `200`-present / `204`-absent contract (HEAD exempt from the `204 → NoResultsException` mapping).

## Notes
- Edits are on the canonical async files only; sync mirrors are regenerated (idempotent) — do not hand-edit `api.py` / `session.py`.
- All 118 offline tests pass; `ruff check` clean.