### PR TITLE
test: quieter pytest output for the live e2e run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,11 +76,17 @@ search = "__version__ = '{current_version}'"
 replace = "__version__ = '{new_version}'"
 
 [tool.pytest.ini_options]
-log_cli = true
-# Default live-log level. INFO keeps the useful app request/response lines while
-# dropping the DEBUG firehose (VCR per-request match trace, parse traces) that
-# otherwise bloats CI logs ~1000x. Override per-run with the TESTS_LOG_LEVEL env
-# var (e.g. TESTS_LOG_LEVEL=DEBUG to log everything); see test/conftest.py.
+# Live logging OFF by default. When on, pytest streams log records as the run goes
+# AND forces every test onto its own nodeid line (verbose-style) — ~130 lines of
+# pure noise on a green xdist run. With it off the run prints dots + an end
+# summary, and a FAILING test still shows its captured logs (at log_level, below)
+# plus the traceback. Opt back into live streaming with TESTS_LOG_CLI=1 (or an
+# explicit --log-cli-level) when debugging a live run; see test/conftest.py.
+log_cli = false
+# Level used for live logging when it's opted into (TESTS_LOG_CLI=1). INFO keeps
+# the useful app request/response lines while dropping the DEBUG firehose (VCR
+# per-request match trace, parse traces) that otherwise bloats logs ~1000x.
+# TESTS_LOG_LEVEL overrides both this and the captured-log level (conftest.py).
 log_cli_level = "INFO"
 log_format = "%(asctime)s %(levelname)-2s [%(name)s:%(filename)s:%(lineno)d:%(funcName)1s()] %(message)s"
 python_files = ["test_*.py", "*_test.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,6 @@ filterwarnings = [
 asyncio_mode = "auto"
 addopts = [
     "--continue-on-collection-errors",
-    "-v",
     "-s",
-    "-rxXs",
+    "-ra",
 ]

--- a/specs/04-testing.md
+++ b/specs/04-testing.md
@@ -226,6 +226,17 @@ The speedup comes from collapsing *sequential* waits. Serial wall-clock is domin
 
 `-n` is deliberately kept out of `[tool.pytest.ini_options].addopts` in `pyproject.toml` and passed on the runner command line instead, so local and IDE runs stay serial (xdist scrambles `-s` live-log ordering and complicates breakpoints). Only the live CI image opts into parallelism. `pytest-xdist` and `pytest-timeout` are in the `[tests]` extra.
 
+### Log output: dots by default, live logs opt-in
+
+The suite prints **one progress char per test** (xdist dots) plus an end-of-run summary — not a line per test. Two things must be off for that, and both were easy to get wrong:
+
+- **`-v` is not in `addopts`** — verbose mode prints every test's nodeid on its own line.
+- **Live logging (`log_cli`) is off by default** — `log_cli = false` in `pyproject.toml`, and `test/conftest.py` does **not** set the `log_cli_level` *option*. This is the subtle one: pytest enables live logging when `log_cli` is true **or** the `log_cli_level` option is set, and live logging *also* forces every test onto its own nodeid line (verbose-style) **regardless of `-v`**. So live logging on a green 8-way run added ~130 noise lines to the harness log even with `-v` removed — the option must be left unset, not just `-v` dropped.
+
+A **failing** test still prints its full traceback and its **captured** logs (the "Captured log call" section, rendered at `log_level` = `TESTS_LOG_LEVEL`, default `INFO`), plus the `-ra` short-summary recap. So the run is quiet on green and detailed on failure.
+
+Opt back into live streaming when debugging a live-stack run with **`TESTS_LOG_CLI=1`** (or an explicit `--log-cli-level=…` on the CLI). `TESTS_LOG_LEVEL=DEBUG` raises both the captured and the live level and unpins the noisy replay/transport libraries (`vcr`, `httpx`, `httpcore`, `asyncio`). See `test/conftest.py`.
+
 ### Why `--timeout-method=thread` and `--timeout=600`
 
 The timeout is a backstop for the live run: VCR-off keeps real poll/sleep pacing, so a non-terminating test would otherwise hang to the CI job limit. `--timeout-method=thread` is the only method that fires reliably here — the signal method can't interrupt a hang inside the asyncio event loop, whereas a watchdog thread fires regardless of loop state, dumps every thread's stack (showing where execution is stuck), then terminates. **Caveat:** the thread method ends the *whole session* on a per-test timeout rather than failing one test, so a hang fails the job with a stack dump instead of running to the job limit. The per-test budget was raised 300 → 600s to give headroom under 8× pipeline contention.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,6 +13,13 @@ _VCR_DIR = os.path.join(os.path.dirname(__file__), "vcr")
 # to log everything (including the replay/transport libraries below).
 _TESTS_LOG_LEVEL = os.getenv("TESTS_LOG_LEVEL", "INFO").upper()
 
+# Live-log streaming (log_cli). OFF by default: when on, pytest not only streams log
+# records but forces every test onto its own nodeid line (verbose-style) — ~130
+# lines of noise on a green xdist run. Off, the run prints dots + an end summary,
+# and a failing test still shows its captured logs at _TESTS_LOG_LEVEL plus the
+# traceback. Set TESTS_LOG_CLI=1 to stream live when debugging a live-stack run.
+_TESTS_LOG_CLI = os.getenv("TESTS_LOG_CLI", "").lower() in ("1", "true", "yes", "on")
+
 # Replay/transport libraries are extremely chatty at DEBUG — vcr.matchers alone
 # logs a full comparison for every recorded request on every call (~24% of the
 # old log) and vcr.cassette/vcr.request dump entire response bodies. Pin them to
@@ -45,12 +52,18 @@ def uid(request):
 
 
 def pytest_configure(config):
-    # Honor an explicit --log-cli-level / --log-level on the CLI; otherwise drive
-    # both the live and captured log level from TESTS_LOG_LEVEL.
-    if config.option.log_cli_level is None:
-        config.option.log_cli_level = _TESTS_LOG_LEVEL
+    # Captured-log level — what pytest records and then prints under a FAILING test
+    # ("Captured log call"). Drive it from TESTS_LOG_LEVEL so failures carry the
+    # app's request/response context while a green run stays quiet. Honors an
+    # explicit --log-level on the CLI.
     if config.option.log_level is None:
         config.option.log_level = _TESTS_LOG_LEVEL
+    # Live logging is enabled iff log_cli (ini, now false) is true OR this option is
+    # set — so setting it here is what turns on the verbose per-test streaming.
+    # Leave it None by default (dots + summary); opt in with TESTS_LOG_CLI=1. An
+    # explicit --log-cli-level on the CLI is honored (already non-None -> untouched).
+    if _TESTS_LOG_CLI and config.option.log_cli_level is None:
+        config.option.log_cli_level = _TESTS_LOG_LEVEL
     noisy_level = "DEBUG" if _TESTS_LOG_LEVEL == "DEBUG" else "WARNING"
     for name in _NOISY_LIBS:
         logging.getLogger(name).setLevel(noisy_level)


### PR DESCRIPTION
## TL;DR
- The live-stack test run now prints **one progress char per test** (dots) + an end-of-run summary instead of ~150 `[gwN] PASSED …` lines of noise.
- Two changes were needed:
  - Drop `-v` from pytest `addopts`; swap `-rxXs` → `-ra` for a compact end recap.
  - Turn **live logging off by default** (`log_cli = false`; `conftest.py` no longer force-sets the `log_cli_level` option) — enabling live logging *also* forces verbose per-test lines regardless of `-v`, so dropping `-v` alone wasn't enough.
- A **failing** test still prints its full traceback + captured logs; `TESTS_LOG_CLI=1` opts back into live streaming when debugging.

## Why
The e2e test image runs this suite 8-way (xdist) against the live stack and streams the output into the harness log. `-v` and live logging (`log_cli`) each independently force pytest to print every test's nodeid on its own line — ~130+ noise lines on a green run. pytest enables live logging when `log_cli` is true **or** the `log_cli_level` option is set, and `conftest.py` was unconditionally setting that option, so it stayed on even after `-v` was removed.

Now the run is quiet on green and detailed on failure (traceback + "Captured log call" at `TESTS_LOG_LEVEL`, plus the `-ra` recap). Live streaming is available on demand via `TESTS_LOG_CLI=1` or an explicit `--log-cli-level`.

Verified by running the image CMD on the pure-unit suite: default → dots; `TESTS_LOG_CLI=1` → verbose restored; an injected failing test → traceback + captured WARNING shown.

Changes: `pyproject.toml` (addopts + `log_cli`), `test/conftest.py` (log-level wiring), `specs/04-testing.md` (documented).