### PR TITLE
test: use the current triage VM slug, not the deprecated win10 one

### DIFF
--- a/test/async_client_test.py
+++ b/test/async_client_test.py
@@ -437,7 +437,7 @@ class TestAsyncScanCase:
             instance, _ = await submit_and_scan(api, uid, wait=False)
             task = await _dispatch_sandbox(api, instance.id, 'cape', 'win-10-build-19041', True)
             assert task.json['config']['network_enabled'] is True
-            task = await _dispatch_sandbox(api, instance.id, 'triage', 'win10-build-15063', False)
+            task = await _dispatch_sandbox(api, instance.id, 'triage', 'windows11-21h2-x64', False)
             assert task.sandbox == 'triage'
             assert task.json['config']['network_enabled'] is False
 
@@ -446,7 +446,7 @@ class TestAsyncScanCase:
         async with self._api() as api:
             instance, sha = await submit_and_scan(api, uid, wait=False)
             cape = await _dispatch_sandbox(api, instance.id, 'cape', 'win-10-build-19041', True)
-            triage = await _dispatch_sandbox(api, instance.id, 'triage', 'win10-build-15063', False)
+            triage = await _dispatch_sandbox(api, instance.id, 'triage', 'windows11-21h2-x64', False)
 
             # No cape/triage VMs in e2e — drive each task to SUCCEEDED by replaying
             # the sandbox worker's HTTP calls. Completing a task creates its
@@ -472,7 +472,7 @@ class TestAsyncScanCase:
             # Dispatch cape + triage concurrently (distinct sandbox slugs, independent).
             await run_concurrently_async([
                 _dispatch_sandbox(api, instance.id, 'cape', 'win-10-build-19041', True),
-                _dispatch_sandbox(api, instance.id, 'triage', 'win10-build-15063', False),
+                _dispatch_sandbox(api, instance.id, 'triage', 'windows11-21h2-x64', False),
             ])
 
             # Poll until the SandboxTaskSearchHash index sees both tasks.
@@ -506,7 +506,7 @@ class TestAsyncScanCase:
         async with self._api() as api:
             instance, sha = await submit_and_scan(api, uid, wait=False)
             cape = await _dispatch_sandbox(api, instance.id, 'cape', 'win-10-build-19041', True)
-            triage = await _dispatch_sandbox(api, instance.id, 'triage', 'win10-build-15063', False)
+            triage = await _dispatch_sandbox(api, instance.id, 'triage', 'windows11-21h2-x64', False)
             await _complete_sandbox_task(cape.id, 'cape')
             await _complete_sandbox_task(triage.id, 'triage')
 

--- a/test/client_scan_test.py
+++ b/test/client_scan_test.py
@@ -802,7 +802,7 @@ class ScanTestCaseV2(TestCase):
 
         task = _dispatch_sandbox(v3api, instance.id, 'cape', 'win-10-build-19041', True)
         assert task.json['config']['network_enabled'] is True
-        task = _dispatch_sandbox(v3api, instance.id, 'triage', 'win10-build-15063', False)
+        task = _dispatch_sandbox(v3api, instance.id, 'triage', 'windows11-21h2-x64', False)
         assert task.sandbox == 'triage'
         assert task.json['config']['network_enabled'] is False
 
@@ -815,7 +815,7 @@ class ScanTestCaseV2(TestCase):
         # is what sandbox_task_latest reads.
         instance, sha256 = submit_and_scan(v3api, self._testMethodName, wait=False)
         cape = _dispatch_sandbox(v3api, instance.id, 'cape', 'win-10-build-19041', True)
-        triage = _dispatch_sandbox(v3api, instance.id, 'triage', 'win10-build-15063', False)
+        triage = _dispatch_sandbox(v3api, instance.id, 'triage', 'windows11-21h2-x64', False)
 
         # _complete_sandbox_task waits (event-driven) for the sandbox service to
         # register each just-dispatched task before driving it to SUCCEEDED.
@@ -839,7 +839,7 @@ class ScanTestCaseV2(TestCase):
         # Dispatch cape + triage concurrently (distinct sandbox slugs, independent).
         run_concurrently([
             lambda: _dispatch_sandbox(v3api, instance.id, 'cape', 'win-10-build-19041', True),
-            lambda: _dispatch_sandbox(v3api, instance.id, 'triage', 'win10-build-15063', False),
+            lambda: _dispatch_sandbox(v3api, instance.id, 'triage', 'windows11-21h2-x64', False),
         ])
 
         # Poll until the SandboxTaskSearchHash index sees both tasks.
@@ -876,7 +876,7 @@ class ScanTestCaseV2(TestCase):
         uid = self._testMethodName
         instance, sha = submit_and_scan(api, uid, wait=False)
         cape = _dispatch_sandbox(api, instance.id, 'cape', 'win-10-build-19041', True)
-        triage = _dispatch_sandbox(api, instance.id, 'triage', 'win10-build-15063', False)
+        triage = _dispatch_sandbox(api, instance.id, 'triage', 'windows11-21h2-x64', False)
         _complete_sandbox_task(cape.id, 'cape')
         _complete_sandbox_task(triage.id, 'triage')
 


### PR DESCRIPTION
## TL;DR
The sandbox tests dispatched `'triage'` with `vm_slug='win10-build-15063'` at **8 call sites**. That isn't a valid triage VM — the server rewrites any slug containing `win10` to `windows11-21h2-x64` for backward compatibility and logs an **ERROR** each time. So every live e2e run carried 8 self-inflicted server-side ERROR lines.

- 8 sites → `'windows11-21h2-x64'` (4 in `client_scan_test.py`, 4 in `async_client_test.py`).
- `triage` offers `windows11-21h2-x64`, `ubuntu-22.04-amd64`, `android-11-x64`; the `win10`-style slug belongs to a different provider.

## Cassettes are deliberately untouched
`vm_slug` travels in the **POST body**, and the VCR matcher is `[method, scheme, host, port, path, query]` — the body isn't matched, so replay is unaffected. Hand-editing cassettes is also against the recording convention (they're produced by running against a live stack). The 8 cassettes that still carry the old recorded body will pick up the new slug naturally the next time they're re-recorded delete-driven.

The server's response was already the rewritten one, so the recorded responses stay correct either way.

## Verification
`pytest test/client_scan_test.py test/async_client_test.py -k "sandbox or sample"` → **13 passed** on replay.